### PR TITLE
fix: 수강신청 새로고침 버튼이 실제 보이는 버튼만 클릭하도록 수정

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "LinKU",
   "description": "건국대학교 학생들을 위한 건국대, 건대 교내외 페이지 모음 링쿠, LinKU",
-  "version": "1.5.46",
+  "version": "1.5.47",
   "action": {
     "default_popup": "index.html"
   },

--- a/src/utils/sugang.ts
+++ b/src/utils/sugang.ts
@@ -1,7 +1,7 @@
 // 수강신청
 export const sugangRefreshBtn = () => {
   const refreshBtn = document.querySelectorAll<HTMLButtonElement>(
-    "#btnRefresh.btn-sm.btn-sub.btn-mode"
+    "div.is-active #btnRefresh.btn-sm.btn-sub.btn-mode"
   );
   refreshBtn.forEach((btn) => {
     btn.click();


### PR DESCRIPTION
## Summary:

fix: 
수강신청 새로고침 버튼이 화면에 실제 보이는 버튼만 클릭하도록 수정하였습니다.

기존 방식은 시나리오 1, 2, 3 등 다른 탭이나 다른 숨겨진 버튼들까지 누르는 문제가 있었습니다.

따라서 적절한 새로고침 버튼들만 선택할 수 있도록 css 선택자를 수정하였습니다.

## Changes:
sugang.ts - sugangRefreshBtn() 함수 내부 querySelecor 내부 문자열 수정
manifest.json - 버전 증가

## Limits
3/9을 마지막으로 수강신청 사이트에서 더 이상 과목을 조회하지 못하는 문제가 있습니다.
따라서 해당 chrome extension 빌드로 실제 웹 환경에서 테스트해보진 못했으나, 당시 테스트 및 실행에 성공한 다른 스크립트와 동일한 css 선택자를 사용하여 높은 확률도 실제 환경에서도 제대로 동작할 것으로 예상합니다.