### PR TITLE
FIX : 로깅 모듈 버그 2종 수정

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,29 @@
-const IS_DEV = import.meta.env.DEV;
+/**
+ * 개발 환경 여부 — debug/info 로그 출력 기준
+ *
+ * ## 왜 import.meta.env.DEV를 쓰지 않는가
+ *
+ * Vite의 `import.meta.env.DEV`는 실행 **명령(command)** 을 기준으로 결정된다.
+ * - `vite` (dev server 실행) → DEV = true
+ * - `vite build`            → DEV = false  ← --mode development를 붙여도 마찬가지
+ *
+ * Vite는 빌드 시 `import.meta.env.*`를 정적 문자열로 치환(static replace)하는데,
+ * DEV/PROD의 치환 기준이 mode가 아닌 command이기 때문에 build 산출물에서는
+ * 항상 false가 된다.
+ *
+ * 결과적으로 `pnpm run build:local` (--mode development) 로 빌드한
+ * 확장 프로그램에서 debugLog/infoLog가 전부 묵음이 되는 버그가 발생한다.
+ *
+ * ## 왜 import.meta.env.MODE를 쓰는가
+ *
+ * `import.meta.env.MODE`는 `--mode` 플래그 값을 그대로 반영한다.
+ * - `vite build --mode development` → MODE = "development"  ✓
+ * - `vite build --mode production`  → MODE = "production"
+ * - `vite build` (기본값)           → MODE = "production"
+ *
+ * 이를 통해 build:local 환경에서 debug 로그가 정상 출력된다.
+ */
+const IS_DEV = import.meta.env.MODE === 'development';
 
 const MAX_STRING_LENGTH = 400;
 const MAX_ARRAY_LENGTH = 20;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -140,21 +140,33 @@ function sanitizeValue(
 
     seen.add(value);
 
-    if (!isPlainObject(value)) {
-      return sanitizeString(String(value));
-    }
+    // non-plain 객체(커스텀 클래스, chrome API 객체 등)는 isPlainObject를 통과 못 해
+    // String() 변환 시 "[object Object]"가 되어 디버깅 불가.
+    // Object.getOwnPropertyNames로 non-enumerable 포함 own property를 추출한다.
+    // (예: chrome.runtime.lastError.message는 non-enumerable이라 Object.keys에 안 잡힘)
+    const allKeys = isPlainObject(value)
+      ? Object.keys(value)
+      : Object.getOwnPropertyNames(value as object);
 
-    const entries = Object.entries(value).slice(0, MAX_OBJECT_KEYS);
-    const sanitizedObject = entries.reduce<Record<string, unknown>>((acc, [key, entryValue]) => {
+    const keys = allKeys.slice(0, MAX_OBJECT_KEYS);
+    const sanitizedObject = keys.reduce<Record<string, unknown>>((acc, key) => {
       acc[key] = SENSITIVE_KEY_PATTERN.test(key)
         ? REDACTED
-        : sanitizeValue(entryValue, depth + 1, seen);
+        : sanitizeValue((value as Record<string, unknown>)[key], depth + 1, seen);
       return acc;
     }, {});
-    const omittedCount = Object.keys(value).length - entries.length;
 
+    const omittedCount = allKeys.length - keys.length;
     if (omittedCount > 0) {
       sanitizedObject[TRUNCATED_OBJECT_META_KEY] = omittedCount;
+    }
+
+    // 클래스 인스턴스라면 타입 힌트 추가
+    if (!isPlainObject(value)) {
+      const typeName = (value as object).constructor?.name;
+      if (typeName && typeName !== "Object") {
+        sanitizedObject["[type]"] = typeName;
+      }
     }
 
     return sanitizedObject;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -32,6 +32,8 @@ const MAX_DEPTH = 4;
 const REDACTED = "[REDACTED]";
 const TRUNCATED_ARRAY_META_KEY = "__truncated_items__";
 const TRUNCATED_OBJECT_META_KEY = "__truncated_keys__";
+const ERROR_ACCESSING_PROPERTY = "[Error accessing property]";
+const UNINSPECTABLE_OBJECT = "[Uninspectable Object]";
 
 const EMAIL_PATTERN =
   /\b([A-Z0-9._%+-])([A-Z0-9._%+-]*)(@[A-Z0-9.-]+\.[A-Z]{2,})\b/gi;
@@ -48,8 +50,29 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     return false;
   }
 
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  } catch {
+    return false;
+  }
+}
+
+function getObjectKeys(value: object, isPlain: boolean): string[] {
+  try {
+    return isPlain ? Object.keys(value) : Object.getOwnPropertyNames(value);
+  } catch {
+    return [];
+  }
+}
+
+function getObjectTypeName(value: object): string | null {
+  try {
+    const typeName = value.constructor?.name;
+    return typeName && typeName !== "Object" ? typeName : null;
+  } catch {
+    return null;
+  }
 }
 
 function sanitizeString(value: string): string {
@@ -104,6 +127,10 @@ function sanitizeValue(
     return sanitizeString(value.toString());
   }
 
+  if (value instanceof RegExp) {
+    return sanitizeString(value.toString());
+  }
+
   if (value instanceof Error) {
     return getErrorLogDetails(value);
   }
@@ -140,19 +167,31 @@ function sanitizeValue(
 
     seen.add(value);
 
+    const plainObject = isPlainObject(value);
+
     // non-plain 객체(커스텀 클래스, chrome API 객체 등)는 isPlainObject를 통과 못 해
     // String() 변환 시 "[object Object]"가 되어 디버깅 불가.
     // Object.getOwnPropertyNames로 non-enumerable 포함 own property를 추출한다.
     // (예: chrome.runtime.lastError.message는 non-enumerable이라 Object.keys에 안 잡힘)
-    const allKeys = isPlainObject(value)
-      ? Object.keys(value)
-      : Object.getOwnPropertyNames(value as object);
+    const allKeys = getObjectKeys(value as object, plainObject);
 
     const keys = allKeys.slice(0, MAX_OBJECT_KEYS);
     const sanitizedObject = keys.reduce<Record<string, unknown>>((acc, key) => {
-      acc[key] = SENSITIVE_KEY_PATTERN.test(key)
-        ? REDACTED
-        : sanitizeValue((value as Record<string, unknown>)[key], depth + 1, seen);
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        acc[key] = REDACTED;
+        return acc;
+      }
+
+      try {
+        acc[key] = sanitizeValue(
+          (value as Record<string, unknown>)[key],
+          depth + 1,
+          seen,
+        );
+      } catch {
+        acc[key] = ERROR_ACCESSING_PROPERTY;
+      }
+
       return acc;
     }, {});
 
@@ -162,11 +201,15 @@ function sanitizeValue(
     }
 
     // 클래스 인스턴스라면 타입 힌트 추가
-    if (!isPlainObject(value)) {
-      const typeName = (value as object).constructor?.name;
-      if (typeName && typeName !== "Object") {
+    if (!plainObject) {
+      const typeName = getObjectTypeName(value as object);
+      if (typeName) {
         sanitizedObject["[type]"] = typeName;
       }
+    }
+
+    if (allKeys.length === 0 && Object.keys(sanitizedObject).length === 0) {
+      return getObjectTypeName(value as object) ?? UNINSPECTABLE_OBJECT;
     }
 
     return sanitizedObject;


### PR DESCRIPTION
#**주요 변경점**
- 로컬 빌드 시 디버그 로그 미노출 버그 수정
- Chrome 내부 객체 로깅 오류 수정
                                                                                                                         
  ### 1. 로컬 빌드 환경에서 디버그 로그가 출력되지 않던 버그

  **문제**
  로컬 테스트용으로 빌드(`build:local`)한 확장 프로그램에서 logger 모듈의 debugLog / infoLog가 전혀 출력되지 않아 디버깅이 사실상 불가능한 상태였습니다.

  **원인**
  로그 출력 여부를 결정하는 `IS_DEV` 값을 빌드 도구(Vite)가 제공하는 개발 모드 플래그로 판단하고 있었는데, 이 플래그는 **로컬 빌드 시 항상 false**로 처리되는 특성이 있었습니다. 즉, 아무리 로컬용 빌드 명령을 써도 프로덕션처럼 동작했습니다.

  **결정**
  빌드 도구 플래그 대신 **빌드 스크립트에 명시된 mode 문자열**을 직접 비교하도록 변경했습니다. `build:local` 스크립트에 `--mode development`가 붙어있는 한 IS_DEV가 정확히 true가 됩니다.

  ---

  ### 2. Chrome 내부 객체가 `[object Object]`로 깨져 보이던 버그

  **문제**
  `chrome.runtime.lastError` 같은 Chrome 브라우저 내부 객체를 로그에 찍으면
  `[object Object]`로만 출력되어 어떤 에러인지 전혀 알 수 없었습니다.

  **원인**
  로거가 "일반 객체가 아닌 것"을 단순 문자열 변환(`String()`)으로 처리했는데,
  Chrome 내부 객체는 프로퍼티(예: `.message`)가 숨겨진 방식으로 저장되어 있어
  일반적인 방법으로는 읽히지 않았습니다.

  **결정**
  숨겨진 프로퍼티까지 읽는 방식(`Object.getOwnPropertyNames`)으로 교체해
  Chrome 내부 객체도 의미있는 내용으로 출력되도록 수정했습니다.
  또한 클래스 인스턴스는 `"[type]": "클래스명"` 힌트를 함께 출력해 타입 파악을 쉽게 했습니다.

  ---

  ## 앞으로의 협업 포인ㄴ트
  - 로컬 테스트 빌드: `pnpm run build:local` → debug/info 로그 정상 출력
  - 프로덕션 빌드: `pnpm run build` → 로그 자동 묵음 (기존과 동일)
  - _**코드에서 로그를 찍을 때는 반드시 `debugLog / infoLog / warnLog / errorLog` 사용**_
    (console.log 직접 호출 금지 — 민감 정보가 배포 빌드에 노출될 위험)

  ## 관리 포인트
  - `build:local` 스크립트에 반드시 `--mode development`가 유지되어야 합니다.
    이 플래그가 빠지면 로컬 빌드에서도 다시 로그가 묵음이 됩니다.

  ## 변경 범위
  `src/utils/logger.ts` 단일 파일, 프로덕션 동작 변경 없음



LINKU 화이띵