### PR TITLE
feat: add notice search and frontend cache

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -229,11 +229,8 @@ flowchart LR
   Cache -->|"즉시 표시"| UI
   Cache --> Fresh{"10분 TTL 이내?"}
   Fresh -->|"예"| Stop["학교 서버 호출 없음"]
-  Fresh -->|"아니요"| Gateway["PublicAlertSourceGateway"]
-  Gateway --> RSS["선택한 RSS"]
-  Gateway --> Career["선택한 취창업 HTML"]
-  RSS --> Merge["안정 ID로 병합"]
-  Career --> Merge
+  Fresh -->|"아니요"| Source["선택한 RSS 또는 취창업 HTML"]
+  Source --> Merge["안정 URL로 병합"]
   Merge --> Cache
 ```
 
@@ -244,14 +241,15 @@ flowchart LR
 - 여러 페이지를 읽은 경우 첫 페이지를 다시 확인합니다. 읽는 도중 목록이
   바뀌었다면 한 번 다시 시작하며, 완전한 경계를 확인하지 못한 결과는 저장하지
   않습니다.
-- 동일 공지는 URL의 게시물 ID로 병합하고, 실패한 source는 기존 캐시와 기준점을
+- 동일 공지는 정규화된 URL로 병합하고, 실패한 source는 기존 캐시와 기준점을
   유지해 다음 화면 진입에서 다시 시도합니다.
+- `chrome.storage.local` 용량을 잠식하지 않도록 source별 최신 500개까지만
+  보존합니다.
 - popup이 닫힌 동안 실행되는 background alarm은 없습니다. 캐시가 만료된 뒤
   사용자가 공지 화면을 열거나 카테고리를 바꿀 때만 network sync가 일어납니다.
 
-현재 gateway는 학교 RSS/HTML에 직접 연결되지만, UI와 캐시 계층은
-`PublicAlertSourceGateway`만 의존합니다. 중앙 수집기가 생기면 같은 계약을
-구현하는 gateway로 교체할 수 있습니다. 단, frontend-only 구조에서는 학교가
+학교 접근은 `fetchPublicAlertPage` 한 함수에 모여 있어 중앙 수집기가 생기면 이
+경계만 교체할 수 있습니다. 단, frontend-only 구조에서는 학교가
 게시물을 source에서 제거하거나 local storage가 삭제된 기간까지 절대적인 무누락을
 보장할 수 없으며, 현재 공개된 목록 안에서 확인 가능한 동기화 경계만 보존합니다.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,6 +217,44 @@ auth code, access token, refresh token, full token response를 로그로 남기�
 깨질 수 있습니다. 이 영역의 변경은 PR에 manual verification notes를 포함해야
 합니다.
 
+### 공지 캐시와 동기화
+
+공개 공지는 backend가 아니라 건국대학교의 카테고리별 RSS 5개와 취창업 HTML
+목록 1개에서 가져옵니다. `src/apis/public-alert-cache.ts`는 이 여섯 source를
+`chrome.storage.local`의 `publicAlertCacheV1`에 source별로 저장합니다.
+
+```mermaid
+flowchart LR
+  UI["공지 탭 또는 카테고리 선택"] --> Cache["source별 로컬 캐시"]
+  Cache -->|"즉시 표시"| UI
+  Cache --> Fresh{"10분 TTL 이내?"}
+  Fresh -->|"예"| Stop["학교 서버 호출 없음"]
+  Fresh -->|"아니요"| Gateway["PublicAlertSourceGateway"]
+  Gateway --> RSS["선택한 RSS"]
+  Gateway --> Career["선택한 취창업 HTML"]
+  RSS --> Merge["안정 ID로 병합"]
+  Career --> Merge
+  Merge --> Cache
+```
+
+- 전체 화면은 만료된 source만 갱신하고, 카테고리 화면은 선택한 source만
+  갱신합니다.
+- 첫 동기화는 최신 한 페이지만 저장합니다. 이후 동기화는 직전 첫 페이지의
+  끝부분을 기준점으로 삼아, 기준점을 다시 만날 때까지 다음 페이지를 읽습니다.
+- 여러 페이지를 읽은 경우 첫 페이지를 다시 확인합니다. 읽는 도중 목록이
+  바뀌었다면 한 번 다시 시작하며, 완전한 경계를 확인하지 못한 결과는 저장하지
+  않습니다.
+- 동일 공지는 URL의 게시물 ID로 병합하고, 실패한 source는 기존 캐시와 기준점을
+  유지해 다음 화면 진입에서 다시 시도합니다.
+- popup이 닫힌 동안 실행되는 background alarm은 없습니다. 캐시가 만료된 뒤
+  사용자가 공지 화면을 열거나 카테고리를 바꿀 때만 network sync가 일어납니다.
+
+현재 gateway는 학교 RSS/HTML에 직접 연결되지만, UI와 캐시 계층은
+`PublicAlertSourceGateway`만 의존합니다. 중앙 수집기가 생기면 같은 계약을
+구현하는 gateway로 교체할 수 있습니다. 단, frontend-only 구조에서는 학교가
+게시물을 source에서 제거하거나 local storage가 삭제된 기간까지 절대적인 무누락을
+보장할 수 없으며, 현재 공개된 목록 안에서 확인 가능한 동기화 경계만 보존합니다.
+
 ## UI 시스템
 
 UI는 다음을 사용합니다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,7 +221,7 @@ auth code, access token, refresh token, full token response를 로그로 남기�
 
 공개 공지는 backend가 아니라 건국대학교의 카테고리별 RSS 5개와 취창업 HTML
 목록 1개에서 가져옵니다. `src/apis/public-alert-cache.ts`는 이 여섯 source를
-`chrome.storage.local`의 `publicAlertCacheV1`에 source별로 저장합니다.
+`chrome.storage.local`의 `publicAlertCacheV1:<source>` 키에 각각 저장합니다.
 
 ```mermaid
 flowchart LR

--- a/src/apis/alerts.ts
+++ b/src/apis/alerts.ts
@@ -11,41 +11,42 @@ import type {
   Department,
   Subscription,
 } from '../types/api';
-import { getAlertsFromRSS } from './external/rss-parser';
-import { getCareerAlertsFromHTML } from './external/html-parser';
+import {
+  getCachedPublicAlerts,
+  syncPublicAlerts,
+} from './public-alert-cache';
 import { errorLog } from '@/utils/logger';
 
 /**
  * Get filtered alerts by category
- * Fetches alerts from RSS/HTML external sources
+ * Returns cached alerts immediately without a network request.
+ */
+export async function getCachedAlerts(
+  params?: AlertFilterParams
+): Promise<GeneralAlert[]> {
+  return getCachedPublicAlerts(params?.category);
+}
+
+/**
+ * Refreshes stale public alert sources and returns the merged cache.
+ * A selected category refreshes only its own source; the all view refreshes
+ * only sources whose individual TTL has expired.
  */
 export async function getAlerts(
   params?: AlertFilterParams
 ): Promise<ApiResponse<GeneralAlert[]>> {
   try {
-    // Fetch from external sources (RSS/HTML parsing)
-    const [rssAlerts, careerAlerts] = await Promise.all([
-      getAlertsFromRSS(),
-      getCareerAlertsFromHTML(6000),
-    ]);
+    const { alerts, allFailed } = await syncPublicAlerts(params?.category);
 
-    const allAlerts = [...rssAlerts, ...careerAlerts];
-
-    // Filter by category if specified
-    if (params?.category) {
-      const filteredAlerts = allAlerts.filter(alert => alert.category === params.category);
+    if (!allFailed || alerts.length > 0) {
       return {
         success: true,
-        data: filteredAlerts,
+        data: alerts,
         status: 200,
       };
     }
 
-    return {
-      success: true,
-      data: allAlerts,
-      status: 200,
-    };
+    throw new Error("All public alert sources failed without cached data");
   } catch (error) {
     errorLog("[Alerts] Failed to fetch alerts from external sources", error);
     return {

--- a/src/apis/external/html-parser.ts
+++ b/src/apis/external/html-parser.ts
@@ -3,6 +3,8 @@ import { debugLog, warnLog, errorLog } from '@/utils/logger';
 
 const CAREER_URL = "https://www.konkuk.ac.kr/combBbs/konkuk/2/list.do";
 
+export const CAREER_ALERT_PAGE_SIZE = 20;
+
 /**
  * Parses HTML table and converts to GeneralAlert array for 취창업 category
  */
@@ -68,7 +70,8 @@ const parseHTMLToAlerts = (
     }
 
     alerts.push({
-      alertId: -(startId + index),
+      // artclId remains stable when rows move between list pages.
+      alertId: viewMatch ? -Number(viewMatch[4]) : -(startId + index),
       title,
       content: "", // HTML page doesn't provide content in list view
       category: "취창업",
@@ -84,21 +87,31 @@ const parseHTMLToAlerts = (
 /**
  * Fetches alerts from 취창업 HTML page
  */
+export const getCareerAlertsPage = async (
+  page: number = 1,
+  startId: number = 6001,
+): Promise<GeneralAlert[]> => {
+  const url = new URL(CAREER_URL);
+  url.searchParams.set("page", String(page));
+  debugLog("Fetching career alerts from:", url.href);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTML fetch failed: ${response.status}`);
+  }
+
+  const htmlText = await response.text();
+  const pageOffset = (page - 1) * CAREER_ALERT_PAGE_SIZE;
+  const alerts = parseHTMLToAlerts(htmlText, startId + pageOffset);
+  debugLog(`Parsed ${alerts.length} career alerts, sample:`, alerts[0]);
+  return alerts;
+};
+
 export const getCareerAlertsFromHTML = async (
-  startId: number = 3001
+  startId: number = 6001,
 ): Promise<GeneralAlert[]> => {
   try {
-    debugLog("Fetching career alerts from:", CAREER_URL);
-    const response = await fetch(CAREER_URL);
-
-    if (!response.ok) {
-      throw new Error(`HTML fetch failed: ${response.status}`);
-    }
-
-    const htmlText = await response.text();
-    const alerts = parseHTMLToAlerts(htmlText, startId);
-    debugLog(`Parsed ${alerts.length} career alerts, sample:`, alerts[0]);
-    return alerts;
+    return await getCareerAlertsPage(1, startId);
   } catch (error) {
     errorLog("Error fetching career HTML:", error);
     return []; // Return empty array on error

--- a/src/apis/external/html-parser.ts
+++ b/src/apis/external/html-parser.ts
@@ -1,7 +1,8 @@
 import type { GeneralAlert } from "../../types/api";
-import { debugLog, warnLog } from '@/utils/logger';
+import { warnLog } from '@/utils/logger';
 
 const CAREER_URL = "https://www.konkuk.ac.kr/combBbs/konkuk/2/list.do";
+const CAREER_FALLBACK_START_ID = 6001;
 
 export const CAREER_ALERT_PAGE_SIZE = 20;
 
@@ -88,12 +89,10 @@ const parseHTMLToAlerts = (
  * Fetches alerts from 취창업 HTML page
  */
 export const getCareerAlertsPage = async (
-  page: number = 1,
-  startId: number = 6001,
+  page: number,
 ): Promise<GeneralAlert[]> => {
   const url = new URL(CAREER_URL);
   url.searchParams.set("page", String(page));
-  debugLog("Fetching career alerts from:", url.href);
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -102,7 +101,5 @@ export const getCareerAlertsPage = async (
 
   const htmlText = await response.text();
   const pageOffset = (page - 1) * CAREER_ALERT_PAGE_SIZE;
-  const alerts = parseHTMLToAlerts(htmlText, startId + pageOffset);
-  debugLog(`Parsed ${alerts.length} career alerts, sample:`, alerts[0]);
-  return alerts;
+  return parseHTMLToAlerts(htmlText, CAREER_FALLBACK_START_ID + pageOffset);
 };

--- a/src/apis/external/html-parser.ts
+++ b/src/apis/external/html-parser.ts
@@ -1,5 +1,5 @@
 import type { GeneralAlert } from "../../types/api";
-import { debugLog, warnLog, errorLog } from '@/utils/logger';
+import { debugLog, warnLog } from '@/utils/logger';
 
 const CAREER_URL = "https://www.konkuk.ac.kr/combBbs/konkuk/2/list.do";
 
@@ -105,15 +105,4 @@ export const getCareerAlertsPage = async (
   const alerts = parseHTMLToAlerts(htmlText, startId + pageOffset);
   debugLog(`Parsed ${alerts.length} career alerts, sample:`, alerts[0]);
   return alerts;
-};
-
-export const getCareerAlertsFromHTML = async (
-  startId: number = 6001,
-): Promise<GeneralAlert[]> => {
-  try {
-    return await getCareerAlertsPage(1, startId);
-  } catch (error) {
-    errorLog("Error fetching career HTML:", error);
-    return []; // Return empty array on error
-  }
 };

--- a/src/apis/external/rss-parser.ts
+++ b/src/apis/external/rss-parser.ts
@@ -88,11 +88,10 @@ const parseRSSToAlerts = (
  */
 export const getAlertsFromRSSPage = async (
   category: RSSAlertCategory,
-  page: number = 1,
-  row: number = RSS_ALERT_PAGE_SIZE,
+  page: number,
 ): Promise<GeneralAlert[]> => {
   const url = new URL(RSS_URLS[category]);
-  url.searchParams.set("row", String(row));
+  url.searchParams.set("row", String(RSS_ALERT_PAGE_SIZE));
   url.searchParams.set("page", String(page));
 
   const response = await fetch(url);
@@ -102,7 +101,7 @@ export const getAlertsFromRSSPage = async (
   }
 
   const xmlText = await response.text();
-  const pageOffset = (page - 1) * row;
+  const pageOffset = (page - 1) * RSS_ALERT_PAGE_SIZE;
   return parseRSSToAlerts(
     xmlText,
     category,

--- a/src/apis/external/rss-parser.ts
+++ b/src/apis/external/rss-parser.ts
@@ -5,11 +5,26 @@ import { errorLog } from '@/utils/logger';
  * RSS URL configuration for each category
  */
 const RSS_URLS: Record<RSSAlertCategory, string> = {
-  학사: "https://www.konkuk.ac.kr/bbs/konkuk/234/rssList.do?row=50",
-  장학: "https://www.konkuk.ac.kr/bbs/konkuk/235/rssList.do?row=50",
-  국제: "https://www.konkuk.ac.kr/bbs/konkuk/237/rssList.do?row=50",
-  학생: "https://www.konkuk.ac.kr/bbs/konkuk/238/rssList.do?row=50",
-  일반: "https://www.konkuk.ac.kr/bbs/konkuk/240/rssList.do?row=50",
+  학사: "https://www.konkuk.ac.kr/bbs/konkuk/234/rssList.do",
+  장학: "https://www.konkuk.ac.kr/bbs/konkuk/235/rssList.do",
+  국제: "https://www.konkuk.ac.kr/bbs/konkuk/237/rssList.do",
+  학생: "https://www.konkuk.ac.kr/bbs/konkuk/238/rssList.do",
+  일반: "https://www.konkuk.ac.kr/bbs/konkuk/240/rssList.do",
+};
+
+export const RSS_ALERT_PAGE_SIZE = 50;
+
+const RSS_CATEGORY_START_IDS: Record<RSSAlertCategory, number> = {
+  학사: 1,
+  장학: 1001,
+  국제: 2001,
+  학생: 3001,
+  일반: 4001,
+};
+
+const getStableAlertId = (link: string, fallbackId: number) => {
+  const articleId = link.match(/\/(\d+)\/artclView\.do/)?.[1];
+  return articleId ? -Number(articleId) : -fallbackId;
 };
 
 /**
@@ -54,7 +69,9 @@ const parseRSSToAlerts = (
     }
 
     alerts.push({
-      alertId: -(startId + index), // Negative IDs to distinguish from API data
+      // The article number in the URL is stable across RSS page shifts.
+      // Keep external IDs negative to distinguish them from backend IDs.
+      alertId: getStableAlertId(link, startId + index),
       title,
       content: description,
       category,
@@ -70,24 +87,28 @@ const parseRSSToAlerts = (
 /**
  * Fetches alerts from a single RSS feed
  */
-const fetchRSSByCategory = async (
+export const getAlertsFromRSSPage = async (
   category: RSSAlertCategory,
-  startId: number
+  page: number = 1,
+  row: number = RSS_ALERT_PAGE_SIZE,
 ): Promise<GeneralAlert[]> => {
-  try {
-    const url = RSS_URLS[category];
-    const response = await fetch(url);
+  const url = new URL(RSS_URLS[category]);
+  url.searchParams.set("row", String(row));
+  url.searchParams.set("page", String(page));
 
-    if (!response.ok) {
-      throw new Error(`RSS fetch failed for ${category}: ${response.status}`);
-    }
+  const response = await fetch(url);
 
-    const xmlText = await response.text();
-    return parseRSSToAlerts(xmlText, category, startId);
-  } catch (error) {
-    errorLog(`Error fetching RSS for ${category}:`, error);
-    return []; // Return empty array on error
+  if (!response.ok) {
+    throw new Error(`RSS fetch failed for ${category}: ${response.status}`);
   }
+
+  const xmlText = await response.text();
+  const pageOffset = (page - 1) * row;
+  return parseRSSToAlerts(
+    xmlText,
+    category,
+    RSS_CATEGORY_START_IDS[category] + pageOffset,
+  );
 };
 
 /**
@@ -106,9 +127,14 @@ export const getAlertsFromRSS = async (): Promise<GeneralAlert[]> => {
 
     // Fetch all RSS feeds in parallel
     const results = await Promise.all(
-      categories.map((category, index) =>
-        fetchRSSByCategory(category, index * 1000 + 1)
-      )
+      categories.map(async (category) => {
+        try {
+          return await getAlertsFromRSSPage(category);
+        } catch (error) {
+          errorLog(`Error fetching RSS for ${category}:`, error);
+          return [];
+        }
+      })
     );
 
     // Combine all results

--- a/src/apis/external/rss-parser.ts
+++ b/src/apis/external/rss-parser.ts
@@ -1,5 +1,4 @@
 import type { GeneralAlert, RSSAlertCategory } from "../../types/api";
-import { errorLog } from '@/utils/logger';
 
 /**
  * RSS URL configuration for each category
@@ -109,38 +108,4 @@ export const getAlertsFromRSSPage = async (
     category,
     RSS_CATEGORY_START_IDS[category] + pageOffset,
   );
-};
-
-/**
- * Fetches alerts from all RSS feeds
- * Fetches all categories in parallel and combines results
- */
-export const getAlertsFromRSS = async (): Promise<GeneralAlert[]> => {
-  try {
-    const categories: RSSAlertCategory[] = [
-      "학사",
-      "장학",
-      "국제",
-      "학생",
-      "일반",
-    ];
-
-    // Fetch all RSS feeds in parallel
-    const results = await Promise.all(
-      categories.map(async (category) => {
-        try {
-          return await getAlertsFromRSSPage(category);
-        } catch (error) {
-          errorLog(`Error fetching RSS for ${category}:`, error);
-          return [];
-        }
-      })
-    );
-
-    // Combine all results
-    return results.flat();
-  } catch (error) {
-    errorLog("Error fetching RSS feeds:", error);
-    throw error;
-  }
 };

--- a/src/apis/public-alert-cache.ts
+++ b/src/apis/public-alert-cache.ts
@@ -14,7 +14,7 @@ import {
   getCareerAlertsPage,
 } from "./external/html-parser";
 
-export const PUBLIC_ALERT_SOURCES: AlertCategory[] = [
+const PUBLIC_ALERT_SOURCES: AlertCategory[] = [
   "학사",
   "장학",
   "국제",
@@ -23,10 +23,9 @@ export const PUBLIC_ALERT_SOURCES: AlertCategory[] = [
   "취창업",
 ];
 
-export const PUBLIC_ALERT_CACHE_TTL_MS = 10 * 60 * 1000;
+const PUBLIC_ALERT_CACHE_TTL_MS = 10 * 60 * 1000;
 
-const PUBLIC_ALERT_CACHE_KEY = "publicAlertCacheV1";
-const PUBLIC_ALERT_CACHE_VERSION = 1;
+const PUBLIC_ALERT_CACHE_KEY_PREFIX = "publicAlertCacheV1";
 const SYNC_ANCHOR_COUNT = 10;
 const MAX_CATCH_UP_PAGES = 100;
 
@@ -34,12 +33,6 @@ interface CachedAlertSource {
   items: GeneralAlert[];
   fetchedAt: number;
   syncAnchorKeys: string[];
-  fullyBackfilled: boolean;
-}
-
-interface PublicAlertCache {
-  version: typeof PUBLIC_ALERT_CACHE_VERSION;
-  sources: Partial<Record<AlertCategory, CachedAlertSource>>;
 }
 
 export interface PublicAlertSourceGateway {
@@ -64,49 +57,36 @@ const schoolPublicAlertGateway: PublicAlertSourceGateway = {
       : RSS_ALERT_PAGE_SIZE,
 };
 
-const emptyCache = (): PublicAlertCache => ({
-  version: PUBLIC_ALERT_CACHE_VERSION,
-  sources: {},
-});
-
-const isPublicAlertCache = (value: unknown): value is PublicAlertCache => {
+const isCachedAlertSource = (value: unknown): value is CachedAlertSource => {
   if (!value || typeof value !== "object") {
     return false;
   }
 
-  const candidate = value as Partial<PublicAlertCache>;
+  const candidate = value as Partial<CachedAlertSource>;
   return (
-    candidate.version === PUBLIC_ALERT_CACHE_VERSION &&
-    Boolean(candidate.sources) &&
-    typeof candidate.sources === "object"
+    Array.isArray(candidate.items) &&
+    typeof candidate.fetchedAt === "number" &&
+    Array.isArray(candidate.syncAnchorKeys)
   );
 };
 
-const readCache = async (): Promise<PublicAlertCache> => {
-  const cached = await getStorage<unknown>(PUBLIC_ALERT_CACHE_KEY);
-  return isPublicAlertCache(cached) ? cached : emptyCache();
-};
+const getSourceCacheKey = (source: AlertCategory) =>
+  `${PUBLIC_ALERT_CACHE_KEY_PREFIX}:${source}`;
 
-let cacheWriteQueue: Promise<void> = Promise.resolve();
+const readSourceCache = async (source: AlertCategory) => {
+  const cached = await getStorage<unknown>(getSourceCacheKey(source));
+  return isCachedAlertSource(cached) ? cached : undefined;
+};
 
 const writeSourceCache = async (
   source: AlertCategory,
   value: CachedAlertSource,
-) => {
-  const write = cacheWriteQueue.then(async () => {
-    const cache = await readCache();
-    cache.sources[source] = value;
-    await setStorage({ [PUBLIC_ALERT_CACHE_KEY]: cache });
-  });
-
-  cacheWriteQueue = write.catch(() => undefined);
-  await write;
-};
+) => setStorage({ [getSourceCacheKey(source)]: value });
 
 const getArticleIdFromUrl = (url?: string) =>
   url?.match(/\/(\d+)\/(?:artclView|view)\.do/)?.[1];
 
-export const getPublicAlertKey = (alert: GeneralAlert) => {
+const getPublicAlertKey = (alert: GeneralAlert) => {
   const articleId = getArticleIdFromUrl(alert.url);
   const fallback = alert.url || `${alert.alertId}:${alert.title}`;
   return `${alert.category}:${articleId || fallback}`;
@@ -165,8 +145,7 @@ const synchronizeSource = async (
   const fetched: GeneralAlert[] = [];
   const pageSize = gateway.getPageSize(source);
   let firstPage: GeneralAlert[] = [];
-  let anchorFound = anchorKeys.size === 0;
-  let exhausted = false;
+  let reachedPreviousBoundary = anchorKeys.size === 0;
   let pagesFetched = 0;
 
   for (let page = 1; page <= MAX_CATCH_UP_PAGES; page += 1) {
@@ -180,24 +159,23 @@ const synchronizeSource = async (
     fetched.push(...pageItems);
 
     if (anchorKeys.size === 0) {
-      exhausted = pageItems.length < pageSize;
       break;
     }
 
     if (
       pageItems.some((alert) => anchorKeys.has(getPublicAlertKey(alert)))
     ) {
-      anchorFound = true;
+      reachedPreviousBoundary = true;
       break;
     }
 
     if (pageItems.length < pageSize) {
-      exhausted = true;
+      reachedPreviousBoundary = true;
       break;
     }
   }
 
-  if (anchorKeys.size > 0 && !anchorFound && !exhausted) {
+  if (!reachedPreviousBoundary) {
     throw new Error(`Alert sync boundary not found for ${source}`);
   }
 
@@ -229,21 +207,14 @@ const synchronizeSource = async (
     syncAnchorKeys: firstPage
       .slice(anchorStart)
       .map(getPublicAlertKey),
-    fullyBackfilled:
-      current?.fullyBackfilled ||
-      (anchorKeys.size > 0 && !anchorFound && exhausted) ||
-      (anchorKeys.size === 0 && exhausted),
   };
 };
 
 const sourceSyncs = new Map<AlertCategory, Promise<CachedAlertSource>>();
 
-export const syncPublicAlertSource = async (
+const syncPublicAlertSource = async (
   source: AlertCategory,
-  options: {
-    force?: boolean;
-    gateway?: PublicAlertSourceGateway;
-  } = {},
+  gateway: PublicAlertSourceGateway,
 ) => {
   const activeSync = sourceSyncs.get(source);
   if (activeSync) {
@@ -251,17 +222,16 @@ export const syncPublicAlertSource = async (
   }
 
   const sync = (async () => {
-    const cache = await readCache();
-    const current = cache.sources[source];
+    const current = await readSourceCache(source);
 
-    if (!options.force && isFresh(current, Date.now())) {
+    if (isFresh(current, Date.now())) {
       return current;
     }
 
     const next = await synchronizeSource(
       source,
       current,
-      options.gateway || schoolPublicAlertGateway,
+      gateway,
     );
     await writeSourceCache(source, next);
     return next;
@@ -279,22 +249,22 @@ export const syncPublicAlertSource = async (
 export const getCachedPublicAlerts = async (
   category?: AlertCategory,
 ): Promise<GeneralAlert[]> => {
-  const cache = await readCache();
   const sources = category ? [category] : PUBLIC_ALERT_SOURCES;
+  const cachedSources = await Promise.all(sources.map(readSourceCache));
 
   return sortByPublishedAt(
-    sources.flatMap((source) => cache.sources[source]?.items || []),
+    cachedSources.flatMap((cached) => cached?.items || []),
   );
 };
 
 export const syncPublicAlerts = async (
   category?: AlertCategory,
-  options: { gateway?: PublicAlertSourceGateway } = {},
+  gateway: PublicAlertSourceGateway = schoolPublicAlertGateway,
 ) => {
   const sources = category ? [category] : PUBLIC_ALERT_SOURCES;
   const results = await Promise.allSettled(
     sources.map((source) =>
-      syncPublicAlertSource(source, { gateway: options.gateway }),
+      syncPublicAlertSource(source, gateway),
     ),
   );
 

--- a/src/apis/public-alert-cache.ts
+++ b/src/apis/public-alert-cache.ts
@@ -3,7 +3,6 @@ import type {
   GeneralAlert,
   RSSAlertCategory,
 } from "@/types/api";
-import { getStorage, setStorage } from "@/utils/chrome";
 import { warnLog } from "@/utils/logger";
 import {
   getAlertsFromRSSPage,
@@ -28,6 +27,7 @@ const PUBLIC_ALERT_CACHE_TTL_MS = 10 * 60 * 1000;
 const PUBLIC_ALERT_CACHE_KEY_PREFIX = "publicAlertCacheV1";
 const SYNC_ANCHOR_COUNT = 10;
 const MAX_CATCH_UP_PAGES = 100;
+const MAX_CACHED_ALERTS_PER_SOURCE = 500;
 
 interface CachedAlertSource {
   items: GeneralAlert[];
@@ -35,27 +35,13 @@ interface CachedAlertSource {
   syncAnchorKeys: string[];
 }
 
-export interface PublicAlertSourceGateway {
-  fetchPage: (
-    source: AlertCategory,
-    page: number,
-  ) => Promise<GeneralAlert[]>;
-  getPageSize: (source: AlertCategory) => number;
-}
+const fetchPublicAlertPage = (source: AlertCategory, page: number) =>
+  source === "취창업"
+    ? getCareerAlertsPage(page)
+    : getAlertsFromRSSPage(source as RSSAlertCategory, page);
 
-const schoolPublicAlertGateway: PublicAlertSourceGateway = {
-  fetchPage: (source, page) => {
-    if (source === "취창업") {
-      return getCareerAlertsPage(page);
-    }
-
-    return getAlertsFromRSSPage(source as RSSAlertCategory, page);
-  },
-  getPageSize: (source) =>
-    source === "취창업"
-      ? CAREER_ALERT_PAGE_SIZE
-      : RSS_ALERT_PAGE_SIZE,
-};
+const getPageSize = (source: AlertCategory) =>
+  source === "취창업" ? CAREER_ALERT_PAGE_SIZE : RSS_ALERT_PAGE_SIZE;
 
 const isCachedAlertSource = (value: unknown): value is CachedAlertSource => {
   if (!value || typeof value !== "object") {
@@ -73,24 +59,26 @@ const isCachedAlertSource = (value: unknown): value is CachedAlertSource => {
 const getSourceCacheKey = (source: AlertCategory) =>
   `${PUBLIC_ALERT_CACHE_KEY_PREFIX}:${source}`;
 
-const readSourceCache = async (source: AlertCategory) => {
-  const cached = await getStorage<unknown>(getSourceCacheKey(source));
-  return isCachedAlertSource(cached) ? cached : undefined;
+const readSourceCaches = async (sources: AlertCategory[]) => {
+  const keys = sources.map(getSourceCacheKey);
+  const stored = await chrome.storage.local.get(keys);
+
+  return keys.map((key) => {
+    const cached: unknown = stored[key];
+    return isCachedAlertSource(cached) ? cached : undefined;
+  });
 };
+
+const readSourceCache = async (source: AlertCategory) =>
+  (await readSourceCaches([source]))[0];
 
 const writeSourceCache = async (
   source: AlertCategory,
   value: CachedAlertSource,
-) => setStorage({ [getSourceCacheKey(source)]: value });
+) => chrome.storage.local.set({ [getSourceCacheKey(source)]: value });
 
-const getArticleIdFromUrl = (url?: string) =>
-  url?.match(/\/(\d+)\/(?:artclView|view)\.do/)?.[1];
-
-const getPublicAlertKey = (alert: GeneralAlert) => {
-  const articleId = getArticleIdFromUrl(alert.url);
-  const fallback = alert.url || `${alert.alertId}:${alert.title}`;
-  return `${alert.category}:${articleId || fallback}`;
-};
+const getPublicAlertKey = (alert: GeneralAlert) =>
+  `${alert.category}:${alert.url || `${alert.alertId}:${alert.title}`}`;
 
 const sortByPublishedAt = (alerts: GeneralAlert[]) =>
   [...alerts].sort(
@@ -108,7 +96,10 @@ const mergeAlerts = (
   cached.forEach((alert) => byKey.set(getPublicAlertKey(alert), alert));
   fetched.forEach((alert) => byKey.set(getPublicAlertKey(alert), alert));
 
-  return sortByPublishedAt([...byKey.values()]);
+  return sortByPublishedAt([...byKey.values()]).slice(
+    0,
+    MAX_CACHED_ALERTS_PER_SOURCE,
+  );
 };
 
 const isFresh = (
@@ -138,18 +129,17 @@ const fingerprintsMatch = (
 const synchronizeSource = async (
   source: AlertCategory,
   current: CachedAlertSource | undefined,
-  gateway: PublicAlertSourceGateway,
   verificationAttempt: number = 0,
 ): Promise<CachedAlertSource> => {
   const anchorKeys = new Set(current?.syncAnchorKeys || []);
   const fetched: GeneralAlert[] = [];
-  const pageSize = gateway.getPageSize(source);
+  const pageSize = getPageSize(source);
   let firstPage: GeneralAlert[] = [];
   let reachedPreviousBoundary = anchorKeys.size === 0;
   let pagesFetched = 0;
 
   for (let page = 1; page <= MAX_CATCH_UP_PAGES; page += 1) {
-    const pageItems = await gateway.fetchPage(source, page);
+    const pageItems = await fetchPublicAlertPage(source, page);
     pagesFetched = page;
 
     if (page === 1) {
@@ -182,14 +172,13 @@ const synchronizeSource = async (
   // Offset pagination can move while multiple pages are being read. Re-check
   // the head once and retry the crawl when it changed during synchronization.
   if (pagesFetched > 1) {
-    const verifiedFirstPage = await gateway.fetchPage(source, 1);
+    const verifiedFirstPage = await fetchPublicAlertPage(source, 1);
 
     if (!fingerprintsMatch(firstPage, verifiedFirstPage)) {
       if (verificationAttempt < 1) {
         return synchronizeSource(
           source,
           current,
-          gateway,
           verificationAttempt + 1,
         );
       }
@@ -212,10 +201,7 @@ const synchronizeSource = async (
 
 const sourceSyncs = new Map<AlertCategory, Promise<CachedAlertSource>>();
 
-const syncPublicAlertSource = async (
-  source: AlertCategory,
-  gateway: PublicAlertSourceGateway,
-) => {
+const syncPublicAlertSource = async (source: AlertCategory) => {
   const activeSync = sourceSyncs.get(source);
   if (activeSync) {
     return activeSync;
@@ -228,11 +214,7 @@ const syncPublicAlertSource = async (
       return current;
     }
 
-    const next = await synchronizeSource(
-      source,
-      current,
-      gateway,
-    );
+    const next = await synchronizeSource(source, current);
     await writeSourceCache(source, next);
     return next;
   })();
@@ -250,7 +232,7 @@ export const getCachedPublicAlerts = async (
   category?: AlertCategory,
 ): Promise<GeneralAlert[]> => {
   const sources = category ? [category] : PUBLIC_ALERT_SOURCES;
-  const cachedSources = await Promise.all(sources.map(readSourceCache));
+  const cachedSources = await readSourceCaches(sources);
 
   return sortByPublishedAt(
     cachedSources.flatMap((cached) => cached?.items || []),
@@ -259,13 +241,10 @@ export const getCachedPublicAlerts = async (
 
 export const syncPublicAlerts = async (
   category?: AlertCategory,
-  gateway: PublicAlertSourceGateway = schoolPublicAlertGateway,
 ) => {
   const sources = category ? [category] : PUBLIC_ALERT_SOURCES;
   const results = await Promise.allSettled(
-    sources.map((source) =>
-      syncPublicAlertSource(source, gateway),
-    ),
+    sources.map(syncPublicAlertSource),
   );
 
   results.forEach((result, index) => {

--- a/src/apis/public-alert-cache.ts
+++ b/src/apis/public-alert-cache.ts
@@ -1,0 +1,314 @@
+import type {
+  AlertCategory,
+  GeneralAlert,
+  RSSAlertCategory,
+} from "@/types/api";
+import { getStorage, setStorage } from "@/utils/chrome";
+import { warnLog } from "@/utils/logger";
+import {
+  getAlertsFromRSSPage,
+  RSS_ALERT_PAGE_SIZE,
+} from "./external/rss-parser";
+import {
+  CAREER_ALERT_PAGE_SIZE,
+  getCareerAlertsPage,
+} from "./external/html-parser";
+
+export const PUBLIC_ALERT_SOURCES: AlertCategory[] = [
+  "학사",
+  "장학",
+  "국제",
+  "학생",
+  "일반",
+  "취창업",
+];
+
+export const PUBLIC_ALERT_CACHE_TTL_MS = 10 * 60 * 1000;
+
+const PUBLIC_ALERT_CACHE_KEY = "publicAlertCacheV1";
+const PUBLIC_ALERT_CACHE_VERSION = 1;
+const SYNC_ANCHOR_COUNT = 10;
+const MAX_CATCH_UP_PAGES = 100;
+
+interface CachedAlertSource {
+  items: GeneralAlert[];
+  fetchedAt: number;
+  syncAnchorKeys: string[];
+  fullyBackfilled: boolean;
+}
+
+interface PublicAlertCache {
+  version: typeof PUBLIC_ALERT_CACHE_VERSION;
+  sources: Partial<Record<AlertCategory, CachedAlertSource>>;
+}
+
+export interface PublicAlertSourceGateway {
+  fetchPage: (
+    source: AlertCategory,
+    page: number,
+  ) => Promise<GeneralAlert[]>;
+  getPageSize: (source: AlertCategory) => number;
+}
+
+const schoolPublicAlertGateway: PublicAlertSourceGateway = {
+  fetchPage: (source, page) => {
+    if (source === "취창업") {
+      return getCareerAlertsPage(page);
+    }
+
+    return getAlertsFromRSSPage(source as RSSAlertCategory, page);
+  },
+  getPageSize: (source) =>
+    source === "취창업"
+      ? CAREER_ALERT_PAGE_SIZE
+      : RSS_ALERT_PAGE_SIZE,
+};
+
+const emptyCache = (): PublicAlertCache => ({
+  version: PUBLIC_ALERT_CACHE_VERSION,
+  sources: {},
+});
+
+const isPublicAlertCache = (value: unknown): value is PublicAlertCache => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<PublicAlertCache>;
+  return (
+    candidate.version === PUBLIC_ALERT_CACHE_VERSION &&
+    Boolean(candidate.sources) &&
+    typeof candidate.sources === "object"
+  );
+};
+
+const readCache = async (): Promise<PublicAlertCache> => {
+  const cached = await getStorage<unknown>(PUBLIC_ALERT_CACHE_KEY);
+  return isPublicAlertCache(cached) ? cached : emptyCache();
+};
+
+let cacheWriteQueue: Promise<void> = Promise.resolve();
+
+const writeSourceCache = async (
+  source: AlertCategory,
+  value: CachedAlertSource,
+) => {
+  const write = cacheWriteQueue.then(async () => {
+    const cache = await readCache();
+    cache.sources[source] = value;
+    await setStorage({ [PUBLIC_ALERT_CACHE_KEY]: cache });
+  });
+
+  cacheWriteQueue = write.catch(() => undefined);
+  await write;
+};
+
+const getArticleIdFromUrl = (url?: string) =>
+  url?.match(/\/(\d+)\/(?:artclView|view)\.do/)?.[1];
+
+export const getPublicAlertKey = (alert: GeneralAlert) => {
+  const articleId = getArticleIdFromUrl(alert.url);
+  const fallback = alert.url || `${alert.alertId}:${alert.title}`;
+  return `${alert.category}:${articleId || fallback}`;
+};
+
+const sortByPublishedAt = (alerts: GeneralAlert[]) =>
+  [...alerts].sort(
+    (left, right) =>
+      new Date(right.publishedAt).getTime() -
+      new Date(left.publishedAt).getTime(),
+  );
+
+const mergeAlerts = (
+  cached: GeneralAlert[],
+  fetched: GeneralAlert[],
+) => {
+  const byKey = new Map<string, GeneralAlert>();
+
+  cached.forEach((alert) => byKey.set(getPublicAlertKey(alert), alert));
+  fetched.forEach((alert) => byKey.set(getPublicAlertKey(alert), alert));
+
+  return sortByPublishedAt([...byKey.values()]);
+};
+
+const isFresh = (
+  entry: CachedAlertSource | undefined,
+  now: number,
+): entry is CachedAlertSource =>
+  Boolean(
+    entry &&
+      entry.fetchedAt > 0 &&
+      now - entry.fetchedAt < PUBLIC_ALERT_CACHE_TTL_MS,
+  );
+
+const fingerprintsMatch = (
+  left: GeneralAlert[],
+  right: GeneralAlert[],
+) => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every(
+    (alert, index) =>
+      getPublicAlertKey(alert) === getPublicAlertKey(right[index]),
+  );
+};
+
+const synchronizeSource = async (
+  source: AlertCategory,
+  current: CachedAlertSource | undefined,
+  gateway: PublicAlertSourceGateway,
+  verificationAttempt: number = 0,
+): Promise<CachedAlertSource> => {
+  const anchorKeys = new Set(current?.syncAnchorKeys || []);
+  const fetched: GeneralAlert[] = [];
+  const pageSize = gateway.getPageSize(source);
+  let firstPage: GeneralAlert[] = [];
+  let anchorFound = anchorKeys.size === 0;
+  let exhausted = false;
+  let pagesFetched = 0;
+
+  for (let page = 1; page <= MAX_CATCH_UP_PAGES; page += 1) {
+    const pageItems = await gateway.fetchPage(source, page);
+    pagesFetched = page;
+
+    if (page === 1) {
+      firstPage = pageItems;
+    }
+
+    fetched.push(...pageItems);
+
+    if (anchorKeys.size === 0) {
+      exhausted = pageItems.length < pageSize;
+      break;
+    }
+
+    if (
+      pageItems.some((alert) => anchorKeys.has(getPublicAlertKey(alert)))
+    ) {
+      anchorFound = true;
+      break;
+    }
+
+    if (pageItems.length < pageSize) {
+      exhausted = true;
+      break;
+    }
+  }
+
+  if (anchorKeys.size > 0 && !anchorFound && !exhausted) {
+    throw new Error(`Alert sync boundary not found for ${source}`);
+  }
+
+  // Offset pagination can move while multiple pages are being read. Re-check
+  // the head once and retry the crawl when it changed during synchronization.
+  if (pagesFetched > 1) {
+    const verifiedFirstPage = await gateway.fetchPage(source, 1);
+
+    if (!fingerprintsMatch(firstPage, verifiedFirstPage)) {
+      if (verificationAttempt < 1) {
+        return synchronizeSource(
+          source,
+          current,
+          gateway,
+          verificationAttempt + 1,
+        );
+      }
+
+      throw new Error(`Alert feed changed during sync for ${source}`);
+    }
+  }
+
+  const mergedItems = mergeAlerts(current?.items || [], fetched);
+  const anchorStart = Math.max(0, firstPage.length - SYNC_ANCHOR_COUNT);
+
+  return {
+    items: mergedItems,
+    fetchedAt: Date.now(),
+    syncAnchorKeys: firstPage
+      .slice(anchorStart)
+      .map(getPublicAlertKey),
+    fullyBackfilled:
+      current?.fullyBackfilled ||
+      (anchorKeys.size > 0 && !anchorFound && exhausted) ||
+      (anchorKeys.size === 0 && exhausted),
+  };
+};
+
+const sourceSyncs = new Map<AlertCategory, Promise<CachedAlertSource>>();
+
+export const syncPublicAlertSource = async (
+  source: AlertCategory,
+  options: {
+    force?: boolean;
+    gateway?: PublicAlertSourceGateway;
+  } = {},
+) => {
+  const activeSync = sourceSyncs.get(source);
+  if (activeSync) {
+    return activeSync;
+  }
+
+  const sync = (async () => {
+    const cache = await readCache();
+    const current = cache.sources[source];
+
+    if (!options.force && isFresh(current, Date.now())) {
+      return current;
+    }
+
+    const next = await synchronizeSource(
+      source,
+      current,
+      options.gateway || schoolPublicAlertGateway,
+    );
+    await writeSourceCache(source, next);
+    return next;
+  })();
+
+  sourceSyncs.set(source, sync);
+
+  try {
+    return await sync;
+  } finally {
+    sourceSyncs.delete(source);
+  }
+};
+
+export const getCachedPublicAlerts = async (
+  category?: AlertCategory,
+): Promise<GeneralAlert[]> => {
+  const cache = await readCache();
+  const sources = category ? [category] : PUBLIC_ALERT_SOURCES;
+
+  return sortByPublishedAt(
+    sources.flatMap((source) => cache.sources[source]?.items || []),
+  );
+};
+
+export const syncPublicAlerts = async (
+  category?: AlertCategory,
+  options: { gateway?: PublicAlertSourceGateway } = {},
+) => {
+  const sources = category ? [category] : PUBLIC_ALERT_SOURCES;
+  const results = await Promise.allSettled(
+    sources.map((source) =>
+      syncPublicAlertSource(source, { gateway: options.gateway }),
+    ),
+  );
+
+  results.forEach((result, index) => {
+    if (result.status === "rejected") {
+      warnLog(`Failed to refresh ${sources[index]} alert cache`, result.reason);
+    }
+  });
+
+  const alerts = await getCachedPublicAlerts(category);
+  const allFailed = results.every((result) => result.status === "rejected");
+
+  return {
+    alerts,
+    allFailed,
+  };
+};

--- a/src/components/Tabs/Alerts/AlertItem.tsx
+++ b/src/components/Tabs/Alerts/AlertItem.tsx
@@ -2,9 +2,11 @@ import type { Alert, AlertCategory } from "@/types/api";
 import { ExternalLink, Calendar } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { sendAlertsItemOpen } from "@/utils/analytics";
+import AlertSearchHighlight from "./AlertSearchHighlight";
 
 interface AlertItemProps {
   alert: Alert;
+  searchQuery?: string;
 }
 
 // 일반 공지 카테고리별 라벨 (표시용)
@@ -30,7 +32,7 @@ const categoryColors: Record<AlertCategory, string> = {
 // 표준 카테고리인지 확인 (학과명인 경우 false)
 const standardCategories = new Set<string>(["일반", "학사", "학생", "장학", "취창업", "국제"]);
 
-const AlertItem = ({ alert }: AlertItemProps) => {
+const AlertItem = ({ alert, searchQuery = "" }: AlertItemProps) => {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     const year = date.getFullYear();
@@ -81,31 +83,39 @@ const AlertItem = ({ alert }: AlertItemProps) => {
               categoryColors[alert.category]
             )}
           >
-            {categoryLabels[alert.category]}
+            <AlertSearchHighlight
+              text={categoryLabels[alert.category]}
+              query={searchQuery}
+            />
           </span>
         )}
         {hasDepartment && (
           <span className="px-2 py-1 rounded text-xs font-medium bg-gray-100 text-gray-700">
-            {alert.department.name}
+            <AlertSearchHighlight
+              text={alert.department.name}
+              query={searchQuery}
+            />
           </span>
         )}
         {isDepartmentFromCategory && (
           <span className="px-2 py-1 rounded text-xs font-medium bg-gray-100 text-gray-700">
-            {alert.category}
+            <AlertSearchHighlight text={alert.category} query={searchQuery} />
           </span>
         )}
       </div>
 
       {/* 제목 */}
       <h3 className="font-medium text-base mb-2 flex items-start justify-between gap-2">
-        <span className="flex-1 break-words">{alert.title}</span>
+        <span className="flex-1 break-words">
+          <AlertSearchHighlight text={alert.title} query={searchQuery} />
+        </span>
         {isClickable && <ExternalLink className="h-4 w-4 flex-shrink-0 mt-0.5" />}
       </h3>
 
       {/* 내용 미리보기 */}
       {alert.content && (
         <p className="text-sm text-muted-foreground mb-3 line-clamp-2 break-words">
-          {alert.content}
+          <AlertSearchHighlight text={alert.content} query={searchQuery} />
         </p>
       )}
 

--- a/src/components/Tabs/Alerts/AlertSearch.tsx
+++ b/src/components/Tabs/Alerts/AlertSearch.tsx
@@ -23,7 +23,7 @@ const AlertSearch = ({ value, onValueChange }: AlertSearchProps) => {
           }
         }}
         aria-label="공지사항 검색"
-        placeholder="공지 제목·내용 검색"
+        placeholder="공지사항의 제목 혹은 내용이 검색 가능합니다"
         autoComplete="off"
         className="pl-9 pr-9 text-sm [&::-webkit-search-cancel-button]:appearance-none"
       />

--- a/src/components/Tabs/Alerts/AlertSearch.tsx
+++ b/src/components/Tabs/Alerts/AlertSearch.tsx
@@ -23,7 +23,7 @@ const AlertSearch = ({ value, onValueChange }: AlertSearchProps) => {
           }
         }}
         aria-label="공지사항 검색"
-        placeholder="공지사항의 제목 혹은 내용이 검색 가능합니다"
+        placeholder="공지사항의 제목 혹은 내용 검색이 가능합니다"
         autoComplete="off"
         className="pl-9 pr-9 text-sm [&::-webkit-search-cancel-button]:appearance-none"
       />

--- a/src/components/Tabs/Alerts/AlertSearch.tsx
+++ b/src/components/Tabs/Alerts/AlertSearch.tsx
@@ -1,0 +1,44 @@
+import { Input } from "@/components/ui/input";
+import { Search, X } from "lucide-react";
+
+interface AlertSearchProps {
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+const AlertSearch = ({ value, onValueChange }: AlertSearchProps) => {
+  return (
+    <div className="relative">
+      <Search
+        aria-hidden="true"
+        className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        type="search"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            onValueChange("");
+          }
+        }}
+        aria-label="공지사항 검색"
+        placeholder="공지 제목·내용 검색"
+        autoComplete="off"
+        className="pl-9 pr-9 text-sm [&::-webkit-search-cancel-button]:appearance-none"
+      />
+      {value.length > 0 && (
+        <button
+          type="button"
+          onClick={() => onValueChange("")}
+          aria-label="검색어 지우기"
+          className="absolute right-1 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <X aria-hidden="true" className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default AlertSearch;

--- a/src/components/Tabs/Alerts/AlertSearchHighlight.tsx
+++ b/src/components/Tabs/Alerts/AlertSearchHighlight.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { getHighlightRanges } from "./alertSearchUtils";
+
+interface AlertSearchHighlightProps {
+  text: string;
+  query?: string;
+}
+
+const AlertSearchHighlight = ({
+  text,
+  query = "",
+}: AlertSearchHighlightProps) => {
+  const ranges = getHighlightRanges(text, query);
+
+  if (ranges.length === 0) {
+    return <>{text}</>;
+  }
+
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+
+  ranges.forEach(({ start, end }) => {
+    if (start > cursor) {
+      parts.push(text.slice(cursor, start));
+    }
+
+    parts.push(
+      <mark
+        key={`${start}-${end}`}
+        className="rounded-sm bg-yellow-200 text-inherit decoration-clone dark:bg-yellow-300/70"
+      >
+        {text.slice(start, end)}
+      </mark>
+    );
+    cursor = end;
+  });
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+
+  return <>{parts}</>;
+};
+
+export default AlertSearchHighlight;

--- a/src/components/Tabs/Alerts/Alerts.tsx
+++ b/src/components/Tabs/Alerts/Alerts.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
-import { getAlerts } from "@/apis";
+import { useState, useEffect, useMemo } from "react";
+import { getAlerts, getCachedAlerts } from "@/apis";
 import type { Alert, AlertCategory } from "@/types/api";
 import { getStorage, setStorage } from "@/utils/chrome";
 import { isLoggedIn as checkLoggedIn } from "@/utils/oauth";
@@ -43,35 +43,6 @@ const Alerts = () => {
   );
   const hasSearchQuery = searchQuery.trim().length > 0;
 
-  // 공지사항 목록 가져오기
-  const fetchAlerts = useCallback(async () => {
-    setIsLoading(true);
-
-    try {
-      const result = await getAlerts(selectedCategory ? { category: selectedCategory } : undefined);
-
-      if (result.success && result.data) {
-        let sortedData = result.data;
-
-        // "전체" 선택 시 날짜/시간 순서대로 정렬 (최신순)
-        if (selectedCategory === undefined) {
-          sortedData = [...result.data].sort((a, b) =>
-            new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
-          );
-        }
-
-        setAlerts(sortedData);
-      } else {
-        toast.error(result.error?.message || "공지사항을 불러오는데 실패했습니다.");
-      }
-    } catch (error) {
-      errorLog("Error fetching alerts:", error);
-      toast.error("공지사항을 불러오는 중 오류가 발생했습니다.");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [selectedCategory]);
-
   // 초기화: 설정 + 로그인 상태를 한 번에 로드
   useEffect(() => {
     const initialize = async () => {
@@ -103,12 +74,63 @@ const Alerts = () => {
     initialize();
   }, []);
 
-  // viewMode가 "all"일 때만 공지사항 가져오기
+  // 캐시를 먼저 표시하고 만료된 source만 뒤에서 갱신한다.
   useEffect(() => {
-    if (viewMode === "all") {
-      fetchAlerts();
+    if (!isInitialized || viewMode !== "all") {
+      return;
     }
-  }, [viewMode, fetchAlerts]);
+
+    let cancelled = false;
+
+    const loadAlerts = async () => {
+      const params = selectedCategory
+        ? { category: selectedCategory }
+        : undefined;
+      let hasCachedAlerts = false;
+      setIsLoading(true);
+
+      try {
+        const cachedAlerts = await getCachedAlerts(params);
+        if (cancelled) return;
+
+        if (cachedAlerts.length > 0) {
+          hasCachedAlerts = true;
+          setAlerts(cachedAlerts);
+          setIsLoading(false);
+        } else {
+          setAlerts([]);
+        }
+
+        const result = await getAlerts(params);
+        if (cancelled) return;
+
+        if (result.success && result.data) {
+          setAlerts(result.data);
+        } else if (!hasCachedAlerts) {
+          toast.error(
+            result.error?.message || "공지사항을 불러오는데 실패했습니다.",
+          );
+        }
+      } catch (error) {
+        if (cancelled) return;
+
+        errorLog("Error fetching alerts:", error);
+        if (!hasCachedAlerts) {
+          toast.error("공지사항을 불러오는 중 오류가 발생했습니다.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadAlerts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isInitialized, selectedCategory, viewMode]);
 
   // 뷰 모드 변경
   const handleViewModeChange = async (mode: AlertViewMode) => {
@@ -179,7 +201,7 @@ const Alerts = () => {
           ) : filteredAlerts.length > 0 ? (
             filteredAlerts.map((alert) => (
               <AlertItem
-                key={alert.alertId}
+                key={alert.url || alert.alertId}
                 alert={alert}
                 searchQuery={searchQuery}
               />

--- a/src/components/Tabs/Alerts/Alerts.tsx
+++ b/src/components/Tabs/Alerts/Alerts.tsx
@@ -178,7 +178,11 @@ const Alerts = () => {
             </div>
           ) : filteredAlerts.length > 0 ? (
             filteredAlerts.map((alert) => (
-              <AlertItem key={alert.alertId} alert={alert} />
+              <AlertItem
+                key={alert.alertId}
+                alert={alert}
+                searchQuery={searchQuery}
+              />
             ))
           ) : (
             <div className="text-center p-8 text-muted-foreground">

--- a/src/components/Tabs/Alerts/Alerts.tsx
+++ b/src/components/Tabs/Alerts/Alerts.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { getAlerts } from "@/apis";
 import type { Alert, AlertCategory } from "@/types/api";
 import { getStorage, setStorage } from "@/utils/chrome";
@@ -6,10 +6,12 @@ import { isLoggedIn as checkLoggedIn } from "@/utils/oauth";
 import { toast } from "sonner";
 import AlertItem from "./AlertItem";
 import AlertFilter from "./AlertFilter";
+import AlertSearch from "./AlertSearch";
 import MyAlertsView from "./MyAlertsView";
 import { Badge } from "@/components/ui/badge";
 import { errorLog } from '@/utils/logger';
 import { sendAlertsView } from '@/utils/analytics';
+import { matchesAlertQuery } from "./alertSearchUtils";
 
 type AlertViewMode = "all" | "my";
 
@@ -33,6 +35,13 @@ const Alerts = () => {
   const [viewMode, setViewMode] = useState<AlertViewMode>("all");
   const [selectedCategory, setSelectedCategory] = useState<AlertCategory | undefined>(undefined);
   const [loggedIn, setLoggedIn] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredAlerts = useMemo(
+    () => alerts.filter((alert) => matchesAlertQuery(alert, searchQuery)),
+    [alerts, searchQuery]
+  );
+  const hasSearchQuery = searchQuery.trim().length > 0;
 
   // 공지사항 목록 가져오기
   const fetchAlerts = useCallback(async () => {
@@ -135,6 +144,8 @@ const Alerts = () => {
           />
         </div>
 
+        <AlertSearch value={searchQuery} onValueChange={setSearchQuery} />
+
         {/* 카테고리 필터 (모든 공지 모드일 때만 표시) */}
         <div className={viewMode === "all" ? "flex gap-2 flex-wrap" : "hidden"}>
           {categories.map((category) => (
@@ -157,7 +168,7 @@ const Alerts = () => {
       >
         {/* 내 공지 모드 */}
         <div className={viewMode === "my" ? "" : "hidden"}>
-          {loggedIn && <MyAlertsView />}
+          {loggedIn && <MyAlertsView searchQuery={searchQuery} />}
         </div>
         {/* 모든 공지 모드 */}
         <div className={viewMode === "all" ? "space-y-3" : "hidden"}>
@@ -165,13 +176,17 @@ const Alerts = () => {
             <div className="flex justify-center p-8">
               <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full"></div>
             </div>
-          ) : alerts.length > 0 ? (
-            alerts.map((alert) => (
+          ) : filteredAlerts.length > 0 ? (
+            filteredAlerts.map((alert) => (
               <AlertItem key={alert.alertId} alert={alert} />
             ))
           ) : (
             <div className="text-center p-8 text-muted-foreground">
-              <p>공지사항이 없습니다</p>
+              <p>
+                {hasSearchQuery && alerts.length > 0
+                  ? "검색 결과가 없습니다."
+                  : "공지사항이 없습니다."}
+              </p>
             </div>
           )}
         </div>

--- a/src/components/Tabs/Alerts/MyAlertsView.tsx
+++ b/src/components/Tabs/Alerts/MyAlertsView.tsx
@@ -26,8 +26,13 @@ import { X, Bell, Loader2, Search } from "lucide-react";
 import { toast } from "sonner";
 import AlertItem from "./AlertItem";
 import { errorLog } from '@/utils/logger';
+import { matchesAlertQuery } from "./alertSearchUtils";
 
-const MyAlertsView = () => {
+interface MyAlertsViewProps {
+  searchQuery: string;
+}
+
+const MyAlertsView = ({ searchQuery }: MyAlertsViewProps) => {
   const [departments, setDepartments] = useState<Department[]>([]);
   const [mySubscriptions, setMySubscriptions] = useState<Subscription[]>([]);
   const [myAlerts, setMyAlerts] = useState<GeneralAlert[]>([]);
@@ -145,6 +150,11 @@ const MyAlertsView = () => {
     });
   }, [myAlerts]);
 
+  const filteredAlerts = useMemo(
+    () => sortedAlerts.filter((alert) => matchesAlertQuery(alert, searchQuery)),
+    [searchQuery, sortedAlerts]
+  );
+
   return (
     <div className="space-y-4">
       {/* 학과 구독 섹션 */}
@@ -229,9 +239,9 @@ const MyAlertsView = () => {
           <div className="flex justify-center p-8">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
           </div>
-        ) : sortedAlerts.length > 0 ? (
+        ) : filteredAlerts.length > 0 ? (
           <div className="space-y-3">
-            {sortedAlerts.map((alert) => (
+            {filteredAlerts.map((alert) => (
               <AlertItem key={alert.alertId} alert={alert} />
             ))}
           </div>
@@ -240,9 +250,13 @@ const MyAlertsView = () => {
             <p>구독한 학과가 없습니다.</p>
             <p className="text-sm mt-1">위에서 학과를 선택해 구독해보세요!</p>
           </div>
-        ) : (
+        ) : sortedAlerts.length === 0 ? (
           <div className="text-center p-8 text-muted-foreground">
             <p>새로운 공지사항이 없습니다.</p>
+          </div>
+        ) : (
+          <div className="text-center p-8 text-muted-foreground">
+            <p>검색 결과가 없습니다.</p>
           </div>
         )}
       </div>

--- a/src/components/Tabs/Alerts/MyAlertsView.tsx
+++ b/src/components/Tabs/Alerts/MyAlertsView.tsx
@@ -242,7 +242,11 @@ const MyAlertsView = ({ searchQuery }: MyAlertsViewProps) => {
         ) : filteredAlerts.length > 0 ? (
           <div className="space-y-3">
             {filteredAlerts.map((alert) => (
-              <AlertItem key={alert.alertId} alert={alert} />
+              <AlertItem
+                key={alert.alertId}
+                alert={alert}
+                searchQuery={searchQuery}
+              />
             ))}
           </div>
         ) : mySubscriptions.length === 0 ? (

--- a/src/components/Tabs/Alerts/alertSearchUtils.ts
+++ b/src/components/Tabs/Alerts/alertSearchUtils.ts
@@ -1,0 +1,23 @@
+import type { Alert } from "@/types/api";
+
+const normalizeSearchText = (value: string) =>
+  value.normalize("NFKC").toLocaleLowerCase("ko-KR");
+
+export const matchesAlertQuery = (alert: Alert, query: string) => {
+  const queryTokens = normalizeSearchText(query)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (queryTokens.length === 0) {
+    return true;
+  }
+
+  const sourceName =
+    "department" in alert ? alert.department.name : alert.category;
+  const searchableText = normalizeSearchText(
+    [alert.title, alert.content, sourceName].filter(Boolean).join(" ")
+  );
+
+  return queryTokens.every((token) => searchableText.includes(token));
+};

--- a/src/components/Tabs/Alerts/alertSearchUtils.ts
+++ b/src/components/Tabs/Alerts/alertSearchUtils.ts
@@ -3,11 +3,14 @@ import type { Alert } from "@/types/api";
 const normalizeSearchText = (value: string) =>
   value.normalize("NFKC").toLocaleLowerCase("ko-KR");
 
-export const matchesAlertQuery = (alert: Alert, query: string) => {
-  const queryTokens = normalizeSearchText(query)
+export const getSearchTokens = (query: string) =>
+  normalizeSearchText(query)
     .trim()
     .split(/\s+/)
     .filter(Boolean);
+
+export const matchesAlertQuery = (alert: Alert, query: string) => {
+  const queryTokens = getSearchTokens(query);
 
   if (queryTokens.length === 0) {
     return true;
@@ -20,4 +23,46 @@ export const matchesAlertQuery = (alert: Alert, query: string) => {
   );
 
   return queryTokens.every((token) => searchableText.includes(token));
+};
+
+export interface HighlightRange {
+  start: number;
+  end: number;
+}
+
+export const getHighlightRanges = (
+  text: string,
+  query: string
+): HighlightRange[] => {
+  const normalizedText = normalizeSearchText(text);
+  const ranges: HighlightRange[] = [];
+
+  for (const token of getSearchTokens(query)) {
+    let searchStart = 0;
+
+    while (searchStart < normalizedText.length) {
+      const matchStart = normalizedText.indexOf(token, searchStart);
+      if (matchStart === -1) break;
+
+      ranges.push({
+        start: matchStart,
+        end: matchStart + token.length,
+      });
+      searchStart = matchStart + token.length;
+    }
+  }
+
+  return ranges
+    .sort((left, right) => left.start - right.start || left.end - right.end)
+    .reduce<HighlightRange[]>((merged, range) => {
+      const previous = merged[merged.length - 1];
+
+      if (previous && range.start <= previous.end) {
+        previous.end = Math.max(previous.end, range.end);
+      } else {
+        merged.push({ ...range });
+      }
+
+      return merged;
+    }, []);
 };

--- a/src/components/Tabs/Alerts/alertSearchUtils.ts
+++ b/src/components/Tabs/Alerts/alertSearchUtils.ts
@@ -3,7 +3,7 @@ import type { Alert } from "@/types/api";
 const normalizeSearchText = (value: string) =>
   value.normalize("NFKC").toLocaleLowerCase("ko-KR");
 
-export const getSearchTokens = (query: string) =>
+const getSearchTokens = (query: string) =>
   normalizeSearchText(query)
     .trim()
     .split(/\s+/)
@@ -25,7 +25,7 @@ export const matchesAlertQuery = (alert: Alert, query: string) => {
   return queryTokens.every((token) => searchableText.includes(token));
 };
 
-export interface HighlightRange {
+interface HighlightRange {
   start: number;
   end: number;
 }


### PR DESCRIPTION
## 변경 요약

- 공지 제목·내용·카테고리·부서명을 검색할 수 있는 검색창을 추가했습니다.
- 검색어와 일치하는 모든 부분을 제목과 내용에서 노란색 형광펜으로 표시합니다.
- 검색어 지우기 버튼과 `Escape` 초기화를 지원합니다.
- 플레이스홀더를 `공지사항의 제목 혹은 내용 검색이 가능합니다`로 적용했습니다.
- 공개 공지 6개 source를 source별 `chrome.storage.local` 캐시로 분리했습니다.
- 저장된 공지를 즉시 보여준 뒤, 10분 TTL이 지난 source만 갱신합니다.
- 카테고리를 선택하면 전체 6개가 아니라 해당 RSS 또는 HTML source 하나만 요청합니다.
- 오래 접속하지 않은 경우 이전 동기화 지점(anchor)을 찾을 때까지 다음 페이지를 읽어 새 공지를 합칩니다.
- source별 동시 요청을 하나의 요청으로 합치고, 갱신 실패 시 기존 캐시를 유지합니다.

## 공지를 불러오는 전체 구조

현재 저장소에는 중앙 공지 수집기가 없으므로 Chrome Extension이 학교 RSS 5개와 취·창업 HTML을 직접 읽습니다. 학교 접근은 `fetchPublicAlertPage` 한 곳에 모아 두어, 나중에 중앙 수집기가 생기면 이 경계만 교체할 수 있습니다.

```mermaid
flowchart LR
    U["사용자"]

    subgraph Popup["Chrome Extension Popup"]
        UI["공지 UI<br/>표시 · 검색 · 노란색 강조"]
        API["Alerts API<br/>UI 응답 형식과 오류 처리"]
        Cache["Public Alert Cache<br/>TTL · anchor · 중복 제거 · single-flight"]
        Reader["Source Reader<br/>fetchPublicAlertPage"]
    end

    Storage[("chrome.storage.local<br/>source별 공지 캐시")]

    subgraph School["현재 외부 데이터 원천"]
        RSS["학교 RSS 5개<br/>페이지당 50개"]
        HTML["취·창업 HTML<br/>페이지당 20개"]
    end

    Collector["향후 중앙 수집기"]

    U --> UI
    UI --> API
    API --> Cache
    Cache <--> Storage
    Cache --> Reader
    Reader --> RSS
    Reader --> HTML
    Reader -. "향후 접근 대상 교체" .-> Collector
```

역할은 다음과 같이 분리했습니다.

- 공지 UI: 표시, 검색, 형광펜 강조, 화면 전환 중 이전 응답 차단
- Alerts API: UI가 사용하는 공지 응답 계약과 오류 변환
- Public Alert Cache: TTL, 이어받기, 병합, 중복 제거, 저장 한도, 동시 요청 제어
- Source Reader: RSS와 취·창업 HTML 페이지 접근

## 실행 시퀀스

캐시가 있으면 네트워크 갱신보다 먼저 화면에 표시합니다. 사용자는 저장된 공지를 즉시 볼 수 있고, 만료된 경우에만 뒤에서 최신 공지를 확인합니다.

```mermaid
sequenceDiagram
    actor U as 사용자
    participant UI as 공지 UI
    participant API as Alerts API
    participant C as 캐시 동기화기
    participant S as chrome.storage.local
    participant K as 학교 RSS 또는 HTML

    U->>UI: 공지 탭 열기 또는 카테고리 선택
    UI->>API: getCachedAlerts(category)
    API->>S: 해당 source 캐시 조회
    S-->>API: 저장된 공지
    API-->>UI: 캐시 즉시 반환
    UI-->>U: 기존 공지 먼저 표시

    UI->>API: getAlerts(category)
    API->>C: syncPublicAlerts(category)
    C->>S: fetchedAt과 anchor 조회

    alt 마지막 수집 후 10분 이내
        C-->>API: 캐시 그대로 반환
    else 캐시 없음 또는 만료
        loop 이전 anchor를 찾을 때까지
            C->>K: 선택 source의 page N 요청
            K-->>C: 공지 목록
        end

        opt 2페이지 이상 읽음
            C->>K: page 1 재확인
            K-->>C: 최신 목록 fingerprint
        end

        C->>C: URL 중복 제거 · 최신순 정렬 · 500개 제한
        C->>S: 갱신된 캐시와 anchor 저장
        C-->>API: 동기화 결과
    end

    API-->>UI: 최종 공지 목록
    UI-->>U: 최신 목록과 검색 강조 표시
```

- 개별 카테고리에서는 선택한 source 하나만 동기화합니다.
- 전체 카테고리에서는 TTL이 지난 source들을 병렬로 동기화합니다.
- 별도의 background alarm은 추가하지 않았습니다. 공지 화면을 열거나 카테고리를 변경할 때 필요한 source를 확인합니다.

## 동기화가 동작하는 원리

### 1. Anchor 기반 이어받기

캐시에는 공지 목록과 갱신 시각뿐 아니라 이전 첫 페이지의 마지막 10개 공지 키를 `syncAnchorKeys`로 저장합니다. 다음 갱신에서는 첫 페이지부터 읽으면서 이 anchor 중 하나가 나올 때까지 페이지를 내려갑니다.

```mermaid
flowchart TD
    A["캐시 만료"] --> B["이전 anchor 10개 로드"]
    B --> C["page 1 요청"]
    C --> D["응답을 임시 목록에 누적"]
    D --> E{"현재 페이지에<br/>이전 anchor가 있는가?"}
    E -- "아니오" --> F{"마지막 페이지인가?"}
    F -- "아니오" --> G["다음 페이지 요청"]
    G --> D
    F -- "예" --> H["수집 종료"]
    E -- "예" --> H
    H --> I["기존 캐시와 병합"]
    I --> J["URL 기준 중복 제거"]
    J --> K["최신순 정렬 후 500개 보관"]
    K --> L["새 anchor 저장"]
```

예를 들어 이전 첫 페이지가 `150 … 101`이고 마지막 10개인 `110 … 101`을 anchor로 저장했다고 가정합니다. 이후 공지 70개가 추가되면 anchor는 세 번째 페이지로 밀립니다.

```text
현재 1페이지: 220 … 171
현재 2페이지: 170 … 121
현재 3페이지: 120 …  71  ← 이전 anchor 발견
```

하나가 삭제되거나 URL이 바뀌는 경우를 견디기 위해 anchor 하나가 아니라 10개를 저장합니다. 첫 동기화에는 anchor가 없으므로 source별 첫 페이지만 기준점으로 저장합니다.

### 2. 첫 페이지 재검증

학교 공지는 offset 기반 페이지이므로 여러 페이지를 읽는 도중 새 공지가 등록되면 페이지 경계가 움직일 수 있습니다. 이를 감지하기 위해 2페이지 이상 읽은 경우 첫 페이지를 한 번 더 받아 처음 목록과 비교합니다.

```mermaid
sequenceDiagram
    participant C as 캐시 동기화기
    participant S as 학교 공지 서버

    C->>S: page 1 요청
    S-->>C: 200번 ~ 151번

    Note over S: 새 공지 201번 등록<br/>기존 공지가 한 칸씩 밀림

    C->>S: page 2 요청
    S-->>C: 151번 ~ 102번

    C->>S: page 1 재확인
    S-->>C: 201번 ~ 152번

    C->>C: 처음 받은 page 1과 다름
    C->>C: 전체 수집을 한 번 재시도
```

재시도 중에도 첫 페이지가 다시 바뀌면 불완전한 결과를 저장하지 않고 갱신을 실패 처리합니다. 이때 기존 캐시는 그대로 유지됩니다.

### 3. Source별 single-flight

React 재실행이나 빠른 화면 전환으로 동일 source 갱신이 겹치면 두 번째 호출은 새 요청을 만들지 않고 이미 진행 중인 Promise를 함께 기다립니다. 카테고리가 다르면 서로 독립적으로 동기화할 수 있습니다.

```mermaid
sequenceDiagram
    participant A as 호출 A
    participant B as 호출 B
    participant M as sourceSyncs
    participant S as 학교 RSS

    A->>M: 학사 동기화 중인가?
    M-->>A: 없음
    A->>M: 학사 Promise 저장
    A->>S: 학사 RSS 요청

    B->>M: 학사 동기화 중인가?
    M-->>B: A가 만든 Promise
    B->>B: 동일 Promise 대기

    S-->>A: 공지 응답
    A-->>B: 동일한 동기화 결과
    A->>M: Promise 제거
```

실패한 Promise가 Map에 남아 다음 갱신을 막지 않도록 성공과 실패 모두 `finally`에서 제거합니다.

## 예상 요청량과 한계

일반 RSS는 페이지당 50개, 취·창업 HTML은 페이지당 20개입니다. RSS의 첫 페이지가 가득 차 있다고 가정하면 대략 다음과 같습니다.

| 새 RSS 공지 수 | 탐색 페이지 | 첫 페이지 검증 포함 요청 수 |
| ---: | ---: | ---: |
| 0~9개 | 1페이지 | 1회 |
| 10~59개 | 2페이지 | 3회 |
| 60~109개 | 3페이지 | 4회 |
| 약 500개 | 11페이지 | 12회 |

- 여러 페이지는 source 내부에서 순차 요청하지만, 전체 보기의 source 6개는 서로 병렬로 동기화합니다.
- source당 최대 500개를 저장해 `chrome.storage.local` 사용량을 제한합니다.
- catch-up은 source당 최대 100페이지까지 시도합니다.
- 100페이지 안에서 anchor를 찾지 못하거나 재시도 중에도 feed가 바뀌면 기존 캐시를 유지합니다.
- 따라서 중앙 수집기가 없는 현재 구조에서 누락 가능성을 크게 줄이는 best-effort 방식이며, 절대적인 무누락 보장은 아닙니다.
- 첫 설치 시에는 과거 전체를 역으로 수집하지 않고 각 source의 최신 첫 페이지만 기준점으로 사용합니다.

## 검색 UX

- 제목, 내용, 카테고리, 부서명을 대소문자 구분 없이 검색합니다.
- 공백으로 나눈 여러 검색어는 모두 만족해야 결과에 포함됩니다.
- 제목과 내용에 일치한 모든 조각을 노란색 `<mark>`로 강조합니다.
- HTML 공지 내용은 텍스트로 정규화한 뒤 검색·강조하므로 기존 HTML을 직접 삽입하지 않습니다.
- 검색 결과가 없을 때 빈 상태를 표시하며, 지우기 버튼과 `Escape`로 검색을 초기화할 수 있습니다.

## 구현 선택

- 확장 프로그램 popup이 닫혀도 캐시를 유지해야 하므로 메모리 전역 대신 [`chrome.storage.local`](https://developer.chrome.com/docs/extensions/reference/api/storage)을 사용했습니다.
- 캐시 먼저 표시한 뒤 갱신하는 흐름에서 이전 Effect의 응답이 새 화면을 덮지 않도록 [`useEffect` cleanup 방식](https://react.dev/reference/react/useEffect)을 적용했습니다.
- SWR이나 TanStack Query는 추가하지 않았습니다. 현재 저장소에 없는 의존성을 추가해도 Chrome storage persistence와 학교 게시판의 anchor pagination은 별도 adapter로 구현해야 하므로, 단일 전용 모듈이 더 작고 경계가 명확합니다.
- Chrome permission, manifest version, backend, background alarm, 별도 캐시 라이브러리는 추가하지 않았습니다.

## 검증

- `pnpm run build:local`
- `pnpm run lint`
- production module과 가짜 RSS/storage를 사용한 Chrome 브라우저 fixture
  - fresh cache에서 두 번째 학교 요청 생략
  - stale cache에서 `1 → 2 → 1` 페이지를 읽고 중복 없이 병합
  - source당 최대 500개 유지
  - 동일 source의 동시 갱신을 하나의 요청으로 통합
- 실제 장학 RSS와 취·창업 HTML에서 1페이지와 2페이지가 서로 다른 응답을 반환하는지 읽기 전용 확인
- 변경 파일 export와 TypeScript `noUnusedLocals` / `noUnusedParameters` 확인
- 500×600 popup에서 검색 placeholder, 제목·내용 강조, 다중 검색어, 빈 결과, 지우기, `Escape`, 카테고리·검색 교집합 확인
