### PR TITLE
feat: automate annual bulletin link updates

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,42 +14,42 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Get current version
         id: version
         run: |
           VERSION=$(node -p "require('./public/manifest.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if release exists
         id: check_release
         run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.tag }}"; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.version.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Release ${{ steps.version.outputs.tag }} already exists, skipping..."
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Creating new release ${{ steps.version.outputs.tag }}..."
           fi
 
       - name: Setup pnpm
         if: steps.check_release.outputs.exists == 'false'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
         if: steps.check_release.outputs.exists == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies
         if: steps.check_release.outputs.exists == 'false'
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build extension
         if: steps.check_release.outputs.exists == 'false'
@@ -60,14 +60,11 @@ jobs:
 
       - name: Create dist.zip
         if: steps.check_release.outputs.exists == 'false'
-        run: |
-          cd dist
-          zip -r ../dist.zip .
-          cd ..
+        run: (cd dist && zip -r ../dist.zip .)
 
       - name: Create Release
         if: steps.check_release.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # 실제 사용자 계정으로 릴리스를 생성하려면 아래 주석을 해제하고 GH_PAT secret을 추가하세요
           # token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -77,6 +77,10 @@ jobs:
             ## LinKU ${{ steps.version.outputs.version }}
 
             ### 설치 방법
+
+            #### [크롬 확장 스토어에서 바로 다운로드하기](https://chromewebstore.google.com/detail/linku/fmfbhmifnohhfiblebbdjlioppfppbgh?hl=ko)
+
+            #### 로컬 설치 방법
             1. dist.zip 파일을 다운로드하고 압축을 풉니다
             2. Chrome 확장 프로그램 페이지에서 "개발자 모드"를 활성화합니다
             3. "압축해제된 확장 프로그램을 로드합니다"를 클릭하고 압축 해제한 폴더를 선택합니다

--- a/src/apis/external/bulletin.ts
+++ b/src/apis/external/bulletin.ts
@@ -1,0 +1,273 @@
+import {
+  BULLETIN_FALLBACK,
+  BULLETIN_FALLBACK_YEAR,
+  createBulletinInfo,
+  type BulletinInfo,
+} from "@/constants/bulletin";
+import { debugLog } from "@/utils/logger";
+
+export type BulletinAvailability = "available" | "unavailable" | "unknown";
+
+interface BulletinCache {
+  resolvedYear: number;
+  attemptedYear: number;
+  checkedAt: number;
+}
+
+export const BULLETIN_CACHE_KEY = "linku:latest-bulletin:v1";
+
+const RETRY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 5_000;
+
+const WAF_SIGNATURES = [
+  "웹 공격 차단",
+  "비정상적인 접근",
+  "access denied",
+  "request blocked",
+];
+
+const ERROR_PAGE_SIGNATURES = [
+  "관리모드",
+  "알림메세지",
+  "존재하지 않는",
+  "페이지를 찾을 수",
+  "page not found",
+];
+
+let sessionResolution:
+  | { calendarYear: number; promise: Promise<BulletinInfo> }
+  | undefined;
+
+function getStorage(): chrome.storage.StorageArea | null {
+  return globalThis.chrome?.storage?.local ?? null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function createInitialCache(): BulletinCache {
+  return {
+    resolvedYear: BULLETIN_FALLBACK_YEAR,
+    attemptedYear: BULLETIN_FALLBACK_YEAR,
+    checkedAt: 0,
+  };
+}
+
+function parseCache(
+  value: unknown,
+  currentYear: number,
+  nowMs: number,
+): BulletinCache {
+  if (!isRecord(value)) {
+    return createInitialCache();
+  }
+
+  const resolvedYear =
+    Number.isInteger(value.resolvedYear) &&
+    Number(value.resolvedYear) >= BULLETIN_FALLBACK_YEAR &&
+    Number(value.resolvedYear) <= currentYear
+      ? Number(value.resolvedYear)
+      : BULLETIN_FALLBACK_YEAR;
+
+  const attemptedYear =
+    Number.isInteger(value.attemptedYear) &&
+    Number(value.attemptedYear) >= resolvedYear &&
+    Number(value.attemptedYear) <= currentYear
+      ? Number(value.attemptedYear)
+      : resolvedYear;
+
+  const checkedAt =
+    typeof value.checkedAt === "number" &&
+    Number.isFinite(value.checkedAt) &&
+    value.checkedAt >= 0 &&
+    value.checkedAt <= nowMs
+      ? value.checkedAt
+      : 0;
+
+  return { resolvedYear, attemptedYear, checkedAt };
+}
+
+function isExpectedSsoRedirect(location: string, year: number): boolean {
+  try {
+    const redirectUrl = new URL(
+      location,
+      createBulletinInfo(year).url,
+    );
+
+    if (redirectUrl.hostname !== "sso.konkuk.ac.kr") {
+      return false;
+    }
+
+    const relayState = redirectUrl.searchParams.get("RelayState");
+    if (!relayState) {
+      return false;
+    }
+
+    const relayUrl = new URL(relayState);
+    const expectedPath = new URL(createBulletinInfo(year).url).pathname;
+
+    return (
+      relayUrl.hostname === "www.konkuk.ac.kr" &&
+      relayUrl.pathname === expectedPath
+    );
+  } catch {
+    return false;
+  }
+}
+
+function classifySuccessfulResponse(body: string, year: number): BulletinAvailability {
+  const normalizedBody = body.toLowerCase();
+
+  if (WAF_SIGNATURES.some((signature) => normalizedBody.includes(signature))) {
+    return "unknown";
+  }
+
+  if (
+    ERROR_PAGE_SIGNATURES.some((signature) =>
+      normalizedBody.includes(signature),
+    )
+  ) {
+    return "unavailable";
+  }
+
+  const shortYear = String(year).slice(-2);
+  const hasBulletinSignature =
+    normalizedBody.includes("요람") || normalizedBody.includes("bulletin");
+  const hasYearSignature =
+    normalizedBody.includes(String(year)) ||
+    normalizedBody.includes(`bulletins${shortYear}`) ||
+    normalizedBody.includes(`bulletin${shortYear}`);
+
+  return hasBulletinSignature && hasYearSignature
+    ? "available"
+    : "unknown";
+}
+
+export async function checkBulletinAvailability(
+  year: number,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<BulletinAvailability> {
+  const controller = new AbortController();
+  const timeoutId = globalThis.setTimeout(
+    () => controller.abort(),
+    REQUEST_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetchImpl(createBulletinInfo(year).url, {
+      method: "GET",
+      redirect: "manual",
+      credentials: "omit",
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (response.type === "opaqueredirect") {
+      return "available";
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      return !location || isExpectedSsoRedirect(location, year)
+        ? "available"
+        : "unknown";
+    }
+
+    if (response.status === 404 || response.status === 410) {
+      return "unavailable";
+    }
+
+    if (response.status !== 200) {
+      return "unknown";
+    }
+
+    return classifySuccessfulResponse(await response.text(), year);
+  } catch (error) {
+    debugLog("[bulletin] Failed to check annual bulletin", error);
+    return "unknown";
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+  }
+}
+
+async function resolveLatestBulletinInternal(
+  now: Date,
+): Promise<BulletinInfo> {
+  const storage = getStorage();
+  const currentYear = now.getFullYear();
+  const nowMs = now.getTime();
+
+  if (
+    !storage ||
+    !Number.isInteger(currentYear) ||
+    !Number.isFinite(nowMs) ||
+    currentYear <= BULLETIN_FALLBACK_YEAR
+  ) {
+    return BULLETIN_FALLBACK;
+  }
+
+  let cache: BulletinCache;
+  try {
+    const stored = await storage.get(BULLETIN_CACHE_KEY);
+    cache = parseCache(stored[BULLETIN_CACHE_KEY], currentYear, nowMs);
+  } catch (error) {
+    debugLog("[bulletin] Failed to read bulletin cache", error);
+    return BULLETIN_FALLBACK;
+  }
+
+  if (cache.resolvedYear >= currentYear) {
+    return createBulletinInfo(cache.resolvedYear);
+  }
+
+  const checkedCurrentYearRecently =
+    cache.attemptedYear === currentYear &&
+    nowMs - cache.checkedAt < RETRY_INTERVAL_MS;
+
+  if (checkedCurrentYearRecently) {
+    return createBulletinInfo(cache.resolvedYear);
+  }
+
+  const candidateYears = [currentYear, currentYear - 1].filter(
+    (year, index, years) =>
+      year > cache.resolvedYear && years.indexOf(year) === index,
+  );
+
+  let resolvedYear = cache.resolvedYear;
+  for (const candidateYear of candidateYears) {
+    const availability = await checkBulletinAvailability(candidateYear);
+    if (availability === "available") {
+      resolvedYear = candidateYear;
+      break;
+    }
+  }
+
+  const updatedCache: BulletinCache = {
+    resolvedYear,
+    attemptedYear: currentYear,
+    checkedAt: nowMs,
+  };
+
+  try {
+    await storage.set({ [BULLETIN_CACHE_KEY]: updatedCache });
+  } catch (error) {
+    debugLog("[bulletin] Failed to persist bulletin cache", error);
+  }
+
+  return createBulletinInfo(resolvedYear);
+}
+
+export function resolveLatestBulletin(
+  now: Date = new Date(),
+): Promise<BulletinInfo> {
+  const calendarYear = now.getFullYear();
+
+  if (!sessionResolution || sessionResolution.calendarYear !== calendarYear) {
+    sessionResolution = {
+      calendarYear,
+      promise: resolveLatestBulletinInternal(now),
+    };
+  }
+
+  return sessionResolution.promise;
+}

--- a/src/apis/external/bulletin.ts
+++ b/src/apis/external/bulletin.ts
@@ -7,6 +7,7 @@ import {
 import { debugLog } from "@/utils/logger";
 
 type BulletinVerification = "verified" | "unverified";
+type BulletinListener = (bulletin: BulletinInfo) => void;
 
 interface BulletinCache {
   resolvedYear: number;
@@ -34,9 +35,10 @@ const UNVERIFIED_PAGE_SIGNATURES = [
   "page not found",
 ];
 
-let sessionResolution:
-  | { calendarYear: number; promise: Promise<BulletinInfo> }
+let sessionRefresh:
+  | { calendarYear: number; promise: Promise<void> }
   | undefined;
+const bulletinListeners = new Set<BulletinListener>();
 
 const INITIAL_CACHE: BulletinCache = {
   resolvedYear: BULLETIN_FALLBACK_YEAR,
@@ -46,6 +48,17 @@ const INITIAL_CACHE: BulletinCache = {
 
 function getStorage(): chrome.storage.StorageArea | null {
   return globalThis.chrome?.storage?.local ?? null;
+}
+
+function notifyBulletinListeners(bulletin: BulletinInfo): void {
+  bulletinListeners.forEach((listener) => listener(bulletin));
+}
+
+export function subscribeLatestBulletin(
+  listener: BulletinListener,
+): () => void {
+  bulletinListeners.add(listener);
+  return () => bulletinListeners.delete(listener);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -187,8 +200,86 @@ async function verifyBulletin(
   }
 }
 
-async function resolveLatestBulletinInternal(
-  now: Date,
+function shouldRefreshBulletin(
+  cache: BulletinCache,
+  currentYear: number,
+  nowMs: number,
+): boolean {
+  if (cache.resolvedYear >= currentYear) {
+    return false;
+  }
+
+  return !(
+    cache.attemptedYear === currentYear &&
+    nowMs - cache.checkedAt < RETRY_INTERVAL_MS
+  );
+}
+
+async function refreshLatestBulletin(
+  storage: chrome.storage.StorageArea,
+  cache: BulletinCache,
+  currentYear: number,
+  nowMs: number,
+): Promise<void> {
+  const candidateYears = [currentYear, currentYear - 1].filter(
+    (year) => year > cache.resolvedYear,
+  );
+  const results = await Promise.all(
+    candidateYears.map(async (year) => ({
+      year,
+      verification: await verifyBulletin(year),
+    })),
+  );
+  const verifiedCandidate = results.find(
+    ({ verification }) => verification === "verified",
+  );
+  const resolvedYear = verifiedCandidate?.year ?? cache.resolvedYear;
+  const updatedCache: BulletinCache = {
+    resolvedYear,
+    attemptedYear: currentYear,
+    checkedAt: nowMs,
+  };
+
+  try {
+    await storage.set({ [BULLETIN_CACHE_KEY]: updatedCache });
+  } catch (error) {
+    debugLog("[bulletin] Failed to persist bulletin cache", error);
+  }
+
+  if (resolvedYear > cache.resolvedYear) {
+    notifyBulletinListeners(createBulletinInfo(resolvedYear));
+  }
+}
+
+function startBulletinRefresh(
+  storage: chrome.storage.StorageArea,
+  cache: BulletinCache,
+  currentYear: number,
+  nowMs: number,
+): void {
+  if (sessionRefresh?.calendarYear === currentYear) {
+    return;
+  }
+
+  const promise = refreshLatestBulletin(
+    storage,
+    cache,
+    currentYear,
+    nowMs,
+  ).catch((error) => {
+    debugLog("[bulletin] Failed to refresh annual bulletin", error);
+  });
+  sessionRefresh = { calendarYear: currentYear, promise };
+
+  void promise.finally(() => {
+    if (sessionRefresh?.promise === promise) {
+      sessionRefresh = undefined;
+    }
+  });
+}
+
+export async function resolveLatestBulletin(
+  now: Date = new Date(),
 ): Promise<BulletinInfo> {
   const storage = getStorage();
   const currentYear = now.getFullYear();
@@ -212,57 +303,9 @@ async function resolveLatestBulletinInternal(
     return BULLETIN_FALLBACK;
   }
 
-  if (cache.resolvedYear >= currentYear) {
-    return createBulletinInfo(cache.resolvedYear);
+  if (shouldRefreshBulletin(cache, currentYear, nowMs)) {
+    startBulletinRefresh(storage, cache, currentYear, nowMs);
   }
 
-  const checkedCurrentYearRecently =
-    cache.attemptedYear === currentYear &&
-    nowMs - cache.checkedAt < RETRY_INTERVAL_MS;
-
-  if (checkedCurrentYearRecently) {
-    return createBulletinInfo(cache.resolvedYear);
-  }
-
-  const candidateYears = [currentYear, currentYear - 1].filter(
-    (year) => year > cache.resolvedYear,
-  );
-
-  let resolvedYear = cache.resolvedYear;
-  for (const candidateYear of candidateYears) {
-    const verification = await verifyBulletin(candidateYear);
-    if (verification === "verified") {
-      resolvedYear = candidateYear;
-      break;
-    }
-  }
-
-  const updatedCache: BulletinCache = {
-    resolvedYear,
-    attemptedYear: currentYear,
-    checkedAt: nowMs,
-  };
-
-  try {
-    await storage.set({ [BULLETIN_CACHE_KEY]: updatedCache });
-  } catch (error) {
-    debugLog("[bulletin] Failed to persist bulletin cache", error);
-  }
-
-  return createBulletinInfo(resolvedYear);
-}
-
-export function resolveLatestBulletin(
-  now: Date = new Date(),
-): Promise<BulletinInfo> {
-  const calendarYear = now.getFullYear();
-
-  if (!sessionResolution || sessionResolution.calendarYear !== calendarYear) {
-    sessionResolution = {
-      calendarYear,
-      promise: resolveLatestBulletinInternal(now),
-    };
-  }
-
-  return sessionResolution.promise;
+  return createBulletinInfo(cache.resolvedYear);
 }

--- a/src/apis/external/bulletin.ts
+++ b/src/apis/external/bulletin.ts
@@ -21,9 +21,12 @@ const REQUEST_TIMEOUT_MS = 5_000;
 
 const WAF_SIGNATURES = [
   "웹 공격 차단",
+  "웹 방화벽",
   "비정상적인 접근",
   "access denied",
   "request blocked",
+  "infra@konkuk.ac.kr",
+  "source ip",
 ];
 
 const ERROR_PAGE_SIGNATURES = [
@@ -88,28 +91,18 @@ function parseCache(
   return { resolvedYear, attemptedYear, checkedAt };
 }
 
-function isExpectedSsoRedirect(location: string, year: number): boolean {
+function isExpectedBulletinPage(responseUrl: string, year: number): boolean {
   try {
-    const redirectUrl = new URL(
-      location,
-      createBulletinInfo(year).url,
-    );
-
-    if (redirectUrl.hostname !== "sso.konkuk.ac.kr") {
-      return false;
-    }
-
-    const relayState = redirectUrl.searchParams.get("RelayState");
-    if (!relayState) {
-      return false;
-    }
-
-    const relayUrl = new URL(relayState);
-    const expectedPath = new URL(createBulletinInfo(year).url).pathname;
+    const finalUrl = new URL(responseUrl);
+    const expectedUrl = new URL(createBulletinInfo(year).url);
+    const expectedPaths = [
+      expectedUrl.pathname,
+      `/sites${expectedUrl.pathname}`,
+    ];
 
     return (
-      relayUrl.hostname === "www.konkuk.ac.kr" &&
-      relayUrl.pathname === expectedPath
+      finalUrl.hostname === expectedUrl.hostname &&
+      expectedPaths.includes(finalUrl.pathname)
     );
   } catch {
     return false;
@@ -155,30 +148,24 @@ export async function checkBulletinAvailability(
   );
 
   try {
+    // An SSO redirect alone does not prove that the annual site exists.
+    // Follow the authenticated chain and validate the final handbook HTML.
     const response = await fetchImpl(createBulletinInfo(year).url, {
       method: "GET",
-      redirect: "manual",
-      credentials: "omit",
+      redirect: "follow",
+      credentials: "include",
       cache: "no-store",
       signal: controller.signal,
     });
-
-    if (response.type === "opaqueredirect") {
-      return "available";
-    }
-
-    if (response.status >= 300 && response.status < 400) {
-      const location = response.headers.get("location");
-      return !location || isExpectedSsoRedirect(location, year)
-        ? "available"
-        : "unknown";
-    }
 
     if (response.status === 404 || response.status === 410) {
       return "unavailable";
     }
 
-    if (response.status !== 200) {
+    if (
+      response.status !== 200 ||
+      !isExpectedBulletinPage(response.url, year)
+    ) {
       return "unknown";
     }
 

--- a/src/apis/external/bulletin.ts
+++ b/src/apis/external/bulletin.ts
@@ -6,7 +6,7 @@ import {
 } from "@/constants/bulletin";
 import { debugLog } from "@/utils/logger";
 
-export type BulletinAvailability = "available" | "unavailable" | "unknown";
+type BulletinAvailability = "available" | "unavailable" | "unknown";
 
 interface BulletinCache {
   resolvedYear: number;
@@ -14,7 +14,7 @@ interface BulletinCache {
   checkedAt: number;
 }
 
-export const BULLETIN_CACHE_KEY = "linku:latest-bulletin:v1";
+const BULLETIN_CACHE_KEY = "linku:latest-bulletin:v1";
 
 const RETRY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 5_000;
@@ -41,6 +41,12 @@ let sessionResolution:
   | { calendarYear: number; promise: Promise<BulletinInfo> }
   | undefined;
 
+const INITIAL_CACHE: BulletinCache = {
+  resolvedYear: BULLETIN_FALLBACK_YEAR,
+  attemptedYear: BULLETIN_FALLBACK_YEAR,
+  checkedAt: 0,
+};
+
 function getStorage(): chrome.storage.StorageArea | null {
   return globalThis.chrome?.storage?.local ?? null;
 }
@@ -49,12 +55,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function createInitialCache(): BulletinCache {
-  return {
-    resolvedYear: BULLETIN_FALLBACK_YEAR,
-    attemptedYear: BULLETIN_FALLBACK_YEAR,
-    checkedAt: 0,
-  };
+function isYearInRange(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= minimum &&
+    value <= maximum
+  );
 }
 
 function parseCache(
@@ -63,22 +74,24 @@ function parseCache(
   nowMs: number,
 ): BulletinCache {
   if (!isRecord(value)) {
-    return createInitialCache();
+    return INITIAL_CACHE;
   }
 
-  const resolvedYear =
-    Number.isInteger(value.resolvedYear) &&
-    Number(value.resolvedYear) >= BULLETIN_FALLBACK_YEAR &&
-    Number(value.resolvedYear) <= currentYear
-      ? Number(value.resolvedYear)
-      : BULLETIN_FALLBACK_YEAR;
+  const resolvedYear = isYearInRange(
+    value.resolvedYear,
+    BULLETIN_FALLBACK_YEAR,
+    currentYear,
+  )
+    ? value.resolvedYear
+    : BULLETIN_FALLBACK_YEAR;
 
-  const attemptedYear =
-    Number.isInteger(value.attemptedYear) &&
-    Number(value.attemptedYear) >= resolvedYear &&
-    Number(value.attemptedYear) <= currentYear
-      ? Number(value.attemptedYear)
-      : resolvedYear;
+  const attemptedYear = isYearInRange(
+    value.attemptedYear,
+    resolvedYear,
+    currentYear,
+  )
+    ? value.attemptedYear
+    : resolvedYear;
 
   const checkedAt =
     typeof value.checkedAt === "number" &&
@@ -109,7 +122,10 @@ function isExpectedBulletinPage(responseUrl: string, year: number): boolean {
   }
 }
 
-function classifySuccessfulResponse(body: string, year: number): BulletinAvailability {
+function classifySuccessfulResponse(
+  body: string,
+  year: number,
+): BulletinAvailability {
   const normalizedBody = body.toLowerCase();
 
   if (WAF_SIGNATURES.some((signature) => normalizedBody.includes(signature))) {
@@ -137,7 +153,7 @@ function classifySuccessfulResponse(body: string, year: number): BulletinAvailab
     : "unknown";
 }
 
-export async function checkBulletinAvailability(
+async function checkBulletinAvailability(
   year: number,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<BulletinAvailability> {
@@ -216,8 +232,7 @@ async function resolveLatestBulletinInternal(
   }
 
   const candidateYears = [currentYear, currentYear - 1].filter(
-    (year, index, years) =>
-      year > cache.resolvedYear && years.indexOf(year) === index,
+    (year) => year > cache.resolvedYear,
   );
 
   let resolvedYear = cache.resolvedYear;

--- a/src/apis/external/bulletin.ts
+++ b/src/apis/external/bulletin.ts
@@ -133,15 +133,19 @@ function verifyBulletinBody(
     return "unverified";
   }
 
-  const shortYear = String(year).slice(-2);
-  const hasBulletinSignature =
-    normalizedBody.includes("요람") || normalizedBody.includes("bulletin");
-  const hasYearSignature =
-    normalizedBody.includes(String(year)) ||
-    normalizedBody.includes(`bulletins${shortYear}`) ||
-    normalizedBody.includes(`bulletin${shortYear}`);
+  const visibleText = normalizedBody
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;|&#160;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const handbookHeading = new RegExp(
+    `${year}(?:학년도)?\\s+건국대학교\\s+(?:온라인\\s*)?요람`,
+  );
 
-  return hasBulletinSignature && hasYearSignature
+  return handbookHeading.test(visibleText)
     ? "verified"
     : "unverified";
 }

--- a/src/apis/external/bulletin.ts
+++ b/src/apis/external/bulletin.ts
@@ -6,7 +6,7 @@ import {
 } from "@/constants/bulletin";
 import { debugLog } from "@/utils/logger";
 
-type BulletinAvailability = "available" | "unavailable" | "unknown";
+type BulletinVerification = "verified" | "unverified";
 
 interface BulletinCache {
   resolvedYear: number;
@@ -19,7 +19,7 @@ const BULLETIN_CACHE_KEY = "linku:latest-bulletin:v1";
 const RETRY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 5_000;
 
-const WAF_SIGNATURES = [
+const UNVERIFIED_PAGE_SIGNATURES = [
   "웹 공격 차단",
   "웹 방화벽",
   "비정상적인 접근",
@@ -27,9 +27,6 @@ const WAF_SIGNATURES = [
   "request blocked",
   "infra@konkuk.ac.kr",
   "source ip",
-];
-
-const ERROR_PAGE_SIGNATURES = [
   "관리모드",
   "알림메세지",
   "존재하지 않는",
@@ -122,22 +119,18 @@ function isExpectedBulletinPage(responseUrl: string, year: number): boolean {
   }
 }
 
-function classifySuccessfulResponse(
+function verifyBulletinBody(
   body: string,
   year: number,
-): BulletinAvailability {
+): BulletinVerification {
   const normalizedBody = body.toLowerCase();
 
-  if (WAF_SIGNATURES.some((signature) => normalizedBody.includes(signature))) {
-    return "unknown";
-  }
-
   if (
-    ERROR_PAGE_SIGNATURES.some((signature) =>
+    UNVERIFIED_PAGE_SIGNATURES.some((signature) =>
       normalizedBody.includes(signature),
     )
   ) {
-    return "unavailable";
+    return "unverified";
   }
 
   const shortYear = String(year).slice(-2);
@@ -149,14 +142,14 @@ function classifySuccessfulResponse(
     normalizedBody.includes(`bulletin${shortYear}`);
 
   return hasBulletinSignature && hasYearSignature
-    ? "available"
-    : "unknown";
+    ? "verified"
+    : "unverified";
 }
 
-async function checkBulletinAvailability(
+async function verifyBulletin(
   year: number,
   fetchImpl: typeof fetch = globalThis.fetch,
-): Promise<BulletinAvailability> {
+): Promise<BulletinVerification> {
   const controller = new AbortController();
   const timeoutId = globalThis.setTimeout(
     () => controller.abort(),
@@ -174,21 +167,17 @@ async function checkBulletinAvailability(
       signal: controller.signal,
     });
 
-    if (response.status === 404 || response.status === 410) {
-      return "unavailable";
-    }
-
     if (
       response.status !== 200 ||
       !isExpectedBulletinPage(response.url, year)
     ) {
-      return "unknown";
+      return "unverified";
     }
 
-    return classifySuccessfulResponse(await response.text(), year);
+    return verifyBulletinBody(await response.text(), year);
   } catch (error) {
     debugLog("[bulletin] Failed to check annual bulletin", error);
-    return "unknown";
+    return "unverified";
   } finally {
     globalThis.clearTimeout(timeoutId);
   }
@@ -237,8 +226,8 @@ async function resolveLatestBulletinInternal(
 
   let resolvedYear = cache.resolvedYear;
   for (const candidateYear of candidateYears) {
-    const availability = await checkBulletinAvailability(candidateYear);
-    if (availability === "available") {
+    const verification = await verifyBulletin(candidateYear);
+    if (verification === "verified") {
       resolvedYear = candidateYear;
       break;
     }

--- a/src/constants/LinkList.ts
+++ b/src/constants/LinkList.ts
@@ -1,4 +1,9 @@
 import { HelloLmsPng } from "@/assets";
+import {
+  BULLETIN_FALLBACK,
+  BULLETIN_LINK_ID,
+  type BulletinInfo,
+} from "@/constants/bulletin";
 import { executeScript, getCurrentTab, updateTabUrl } from "@/utils/chrome";
 import {
   sugangRefreshBtn,
@@ -31,6 +36,7 @@ export interface SameHost {
 }
 
 export interface LinkListElement {
+  id?: string;
   icon: LucideIcon | string;
   label: string;
   link: string;
@@ -177,9 +183,10 @@ export const LinkList: LinkListElement[] = [
 
   // row6
   {
+    id: BULLETIN_LINK_ID,
     icon: ScrollText,
-    label: "2026 요람",
-    link: "https://www.konkuk.ac.kr/bulletins26/index.do",
+    label: BULLETIN_FALLBACK.label,
+    link: BULLETIN_FALLBACK.url,
   },
   {
     icon: Building,
@@ -192,3 +199,13 @@ export const LinkList: LinkListElement[] = [
     link: "https://startup.konkuk.ac.kr",
   },
 ];
+
+export function createLinkList(
+  bulletin: BulletinInfo = BULLETIN_FALLBACK,
+): LinkListElement[] {
+  return LinkList.map((item) =>
+    item.id === BULLETIN_LINK_ID
+      ? { ...item, label: bulletin.label, link: bulletin.url }
+      : item,
+  );
+}

--- a/src/constants/LinkList.ts
+++ b/src/constants/LinkList.ts
@@ -200,7 +200,7 @@ export const LinkList: LinkListElement[] = [
   },
 ];
 
-export function createLinkList(
+export function createDefaultLinkList(
   bulletin: BulletinInfo = BULLETIN_FALLBACK,
 ): LinkListElement[] {
   return LinkList.map((item) =>

--- a/src/constants/LinkList.ts
+++ b/src/constants/LinkList.ts
@@ -178,8 +178,8 @@ export const LinkList: LinkListElement[] = [
   // row6
   {
     icon: ScrollText,
-    label: "2025 요람",
-    link: "https://www.konkuk.ac.kr/sites/bulletins25/index.do",
+    label: "2026 요람",
+    link: "https://www.konkuk.ac.kr/bulletins26/index.do",
   },
   {
     icon: Building,

--- a/src/constants/bulletin.ts
+++ b/src/constants/bulletin.ts
@@ -1,0 +1,22 @@
+export interface BulletinInfo {
+  year: number;
+  label: string;
+  url: string;
+}
+
+export const BULLETIN_FALLBACK_YEAR = 2026;
+export const BULLETIN_LINK_ID = "official-bulletin";
+
+export function createBulletinInfo(year: number): BulletinInfo {
+  const shortYear = String(year).slice(-2);
+
+  return {
+    year,
+    label: `${year} 요람`,
+    url: `https://www.konkuk.ac.kr/bulletins${shortYear}/index.do`,
+  };
+}
+
+export const BULLETIN_FALLBACK = createBulletinInfo(
+  BULLETIN_FALLBACK_YEAR,
+);

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -7,6 +7,8 @@ import { useReducer, useEffect, ReactNode } from 'react';
 import type { Template, TemplateItem, Icon } from '@/types/api';
 import { getTemplate } from '@/apis/templates';
 import { getDefaultIcons, getMyIcons } from '@/apis/icons';
+import { resolveLatestBulletin } from '@/apis/external/bulletin';
+import { createLinkList } from '@/constants/LinkList';
 import { convertLinkListToTemplateItems, calculateTemplateHeight } from '@/utils/template';
 import { loadTemplateFromLocalStorage } from '@/utils/templateStorage';
 import { toast } from 'sonner';
@@ -475,9 +477,10 @@ export const EditorProvider = ({ children, templateId, startFrom }: EditorProvid
 
     try {
       // Fetch both default icons and user icons in parallel
-      const [iconsResult, userIconsResult] = await Promise.allSettled([
+      const [iconsResult, userIconsResult, bulletinResult] = await Promise.allSettled([
         getDefaultIcons(),
         getMyIcons(),
+        resolveLatestBulletin(),
       ]);
 
       debugLog('[EditorContext] Icons API full response:', iconsResult);
@@ -542,7 +545,15 @@ export const EditorProvider = ({ children, templateId, startFrom }: EditorProvid
           };
           dispatch({ type: 'LOAD_TEMPLATE', payload: emptyTemplate });
         } else {
-          const templateItems = convertLinkListToTemplateItems(defaultIcons);
+          const defaultLinks = createLinkList(
+            bulletinResult.status === 'fulfilled'
+              ? bulletinResult.value
+              : undefined,
+          );
+          const templateItems = convertLinkListToTemplateItems(
+            defaultIcons,
+            defaultLinks,
+          );
           const templateHeight = calculateTemplateHeight();
 
           const newTemplate: Template = {

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -8,7 +8,8 @@ import type { Template, TemplateItem, Icon } from '@/types/api';
 import { getTemplate } from '@/apis/templates';
 import { getDefaultIcons, getMyIcons } from '@/apis/icons';
 import { resolveLatestBulletin } from '@/apis/external/bulletin';
-import { createLinkList } from '@/constants/LinkList';
+import { createDefaultLinkList } from '@/constants/LinkList';
+import { BULLETIN_FALLBACK } from '@/constants/bulletin';
 import { convertLinkListToTemplateItems, calculateTemplateHeight } from '@/utils/template';
 import { loadTemplateFromLocalStorage } from '@/utils/templateStorage';
 import { toast } from 'sonner';
@@ -476,11 +477,13 @@ export const EditorProvider = ({ children, templateId, startFrom }: EditorProvid
     dispatch({ type: 'SET_LOADING', payload: true });
 
     try {
-      // Fetch both default icons and user icons in parallel
+      // Fetch editor icons and resolve the bulletin only for default templates.
       const [iconsResult, userIconsResult, bulletinResult] = await Promise.allSettled([
         getDefaultIcons(),
         getMyIcons(),
-        resolveLatestBulletin(),
+        startFrom === 'empty'
+          ? Promise.resolve(BULLETIN_FALLBACK)
+          : resolveLatestBulletin(),
       ]);
 
       debugLog('[EditorContext] Icons API full response:', iconsResult);
@@ -545,7 +548,7 @@ export const EditorProvider = ({ children, templateId, startFrom }: EditorProvid
           };
           dispatch({ type: 'LOAD_TEMPLATE', payload: emptyTemplate });
         } else {
-          const defaultLinks = createLinkList(
+          const defaultLinks = createDefaultLinkList(
             bulletinResult.status === 'fulfilled'
               ? bulletinResult.value
               : undefined,

--- a/src/hooks/useSelectedTemplate.ts
+++ b/src/hooks/useSelectedTemplate.ts
@@ -10,7 +10,7 @@ import { resolveLatestBulletin } from "@/apis/external/bulletin";
 import type { Template } from "@/types/api";
 import {
   LinkList,
-  createLinkList,
+  createDefaultLinkList,
   type LinkListElement,
 } from "@/constants/LinkList";
 import { loadTemplateFromLocalStorage } from "@/utils/templateStorage";
@@ -73,7 +73,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
         return;
       }
 
-      const resolvedLinkItems = createLinkList(bulletin);
+      const resolvedLinkItems = createDefaultLinkList(bulletin);
       defaultLinkItemsRef.current = resolvedLinkItems;
 
       if (selectedTemplateIdRef.current === null) {

--- a/src/hooks/useSelectedTemplate.ts
+++ b/src/hooks/useSelectedTemplate.ts
@@ -6,13 +6,17 @@
 
 import { useEffect, useRef, useState } from "react";
 import { getTemplate } from "@/apis/templates";
-import { resolveLatestBulletin } from "@/apis/external/bulletin";
+import {
+  resolveLatestBulletin,
+  subscribeLatestBulletin,
+} from "@/apis/external/bulletin";
 import type { Template } from "@/types/api";
 import {
   LinkList,
   createDefaultLinkList,
   type LinkListElement,
 } from "@/constants/LinkList";
+import type { BulletinInfo } from "@/constants/bulletin";
 import { loadTemplateFromLocalStorage } from "@/utils/templateStorage";
 import { debugLog, errorLog } from '@/utils/logger';
 
@@ -57,6 +61,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
   const loadRequestIdRef = useRef(0);
   const selectedTemplateIdRef = useRef<number | null>(selectedTemplateId);
   const defaultLinkItemsRef = useRef<LinkListElement[]>(LinkList);
+  const bulletinYearRef = useRef(0);
 
   selectedTemplateIdRef.current = selectedTemplateId;
 
@@ -68,21 +73,26 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
   useEffect(() => {
     let cancelled = false;
 
-    void resolveLatestBulletin().then((bulletin) => {
-      if (cancelled) {
+    const applyBulletin = (bulletin: BulletinInfo) => {
+      if (cancelled || bulletin.year < bulletinYearRef.current) {
         return;
       }
 
+      bulletinYearRef.current = bulletin.year;
       const resolvedLinkItems = createDefaultLinkList(bulletin);
       defaultLinkItemsRef.current = resolvedLinkItems;
 
       if (selectedTemplateIdRef.current === null) {
         setLinkItems(resolvedLinkItems);
       }
-    });
+    };
+    const unsubscribe = subscribeLatestBulletin(applyBulletin);
+
+    void resolveLatestBulletin().then(applyBulletin);
 
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, []);
 

--- a/src/hooks/useSelectedTemplate.ts
+++ b/src/hooks/useSelectedTemplate.ts
@@ -6,8 +6,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import { getTemplate } from "@/apis/templates";
+import { resolveLatestBulletin } from "@/apis/external/bulletin";
 import type { Template } from "@/types/api";
-import { LinkList, LinkListElement } from "@/constants/LinkList";
+import {
+  LinkList,
+  createLinkList,
+  type LinkListElement,
+} from "@/constants/LinkList";
 import { loadTemplateFromLocalStorage } from "@/utils/templateStorage";
 import { debugLog, errorLog } from '@/utils/logger';
 
@@ -51,12 +56,34 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
   const [hasLoadedSelection, setHasLoadedSelection] = useState(false);
   const loadRequestIdRef = useRef(0);
   const selectedTemplateIdRef = useRef<number | null>(selectedTemplateId);
+  const defaultLinkItemsRef = useRef<LinkListElement[]>(LinkList);
 
   selectedTemplateIdRef.current = selectedTemplateId;
 
   // Load selected template ID from Chrome storage on mount
   useEffect(() => {
     loadSelectedTemplate();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void resolveLatestBulletin().then((bulletin) => {
+      if (cancelled) {
+        return;
+      }
+
+      const resolvedLinkItems = createLinkList(bulletin);
+      defaultLinkItemsRef.current = resolvedLinkItems;
+
+      if (selectedTemplateIdRef.current === null) {
+        setLinkItems(resolvedLinkItems);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Listen for storage changes from other contexts (real-time sync)
@@ -89,7 +116,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
           loadRequestIdRef.current += 1;
           setSelectedTemplateId(null);
           setTemplateData(null);
-          setLinkItems(LinkList);
+          setLinkItems(defaultLinkItemsRef.current);
           setError(null);
           setIsLoading(false);
           return;
@@ -121,7 +148,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
     } else {
       // No template selected - use default LinkList
       setTemplateData(null);
-      setLinkItems(LinkList);
+      setLinkItems(defaultLinkItemsRef.current);
       setIsLoading(false);
     }
   }, [hasLoadedSelection, selectedTemplateId]);
@@ -132,7 +159,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
       const storage = getChromeStorage();
       if (!storage?.local) {
         setSelectedTemplateId(null);
-        setLinkItems(LinkList);
+        setLinkItems(defaultLinkItemsRef.current);
         return;
       }
 
@@ -150,7 +177,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
           "[useSelectedTemplate] Converting 0 to null (default template)",
         );
         setSelectedTemplateId(null);
-        setLinkItems(LinkList);
+        setLinkItems(defaultLinkItemsRef.current);
       } else if (templateId && typeof templateId === "number") {
         debugLog("[useSelectedTemplate] Setting templateId:", templateId);
         setSelectedTemplateId(templateId);
@@ -160,12 +187,12 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
           "[useSelectedTemplate] No template selected, using default",
         );
         setSelectedTemplateId(null);
-        setLinkItems(LinkList);
+        setLinkItems(defaultLinkItemsRef.current);
       }
     } catch (err) {
       errorLog("Failed to load selected template:", err);
       setError("템플릿을 불러오는데 실패했습니다.");
-      setLinkItems(LinkList);
+      setLinkItems(defaultLinkItemsRef.current);
       setSelectedTemplateId(null);
     } finally {
       setHasLoadedSelection(true);
@@ -215,7 +242,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
         setError(result.error?.message || "템플릿을 불러올 수 없습니다.");
         setTemplateData(null);
         setSelectedTemplateId(null);
-        setLinkItems(LinkList);
+        setLinkItems(defaultLinkItemsRef.current);
       }
     } catch (err) {
       if (isStaleRequest()) {
@@ -226,7 +253,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
       setError("템플릿 로딩 중 오류가 발생했습니다.");
       setTemplateData(null);
       setSelectedTemplateId(null);
-      setLinkItems(LinkList);
+      setLinkItems(defaultLinkItemsRef.current);
     } finally {
       if (!isStaleRequest()) {
         setIsLoading(false);
@@ -246,7 +273,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
           loadRequestIdRef.current += 1;
           setSelectedTemplateId(null);
           setTemplateData(null);
-          setLinkItems(LinkList);
+          setLinkItems(defaultLinkItemsRef.current);
           setError(null);
           setIsLoading(false);
         } else {
@@ -264,7 +291,7 @@ export function useSelectedTemplate(): UseSelectedTemplateResult {
         await storage.local.remove(STORAGE_KEY);
         setSelectedTemplateId(null);
         setTemplateData(null);
-        setLinkItems(LinkList);
+        setLinkItems(defaultLinkItemsRef.current);
         setError(null);
         setIsLoading(false);
       } else {

--- a/src/pages/TemplateListPage.tsx
+++ b/src/pages/TemplateListPage.tsx
@@ -28,11 +28,12 @@ import { useSelectedTemplate } from '@/hooks/useSelectedTemplate';
 import { usePostedTemplates } from '@/hooks/usePostedTemplates';
 import { useTemplateSync } from '@/hooks/useTemplateSync';
 import { useTemplatePublish } from '@/hooks/useTemplatePublish';
+import { resolveLatestBulletin } from '@/apis/external/bulletin';
 import { getTemplatesIndex, loadTemplateFromLocalStorage, deleteTemplateFromLocalStorage } from '@/utils/templateStorage';
 import { getErrorMessage } from '@/utils/apiErrorHandler';
 import { convertLinkListToTemplateItems, convertLucideIconToDataUri } from '@/utils/template';
 import { areItemsEqual } from '@/utils/templateUtils';
-import { LinkList } from '@/constants/LinkList';
+import { createLinkList } from '@/constants/LinkList';
 import { isLoggedIn } from '@/utils/oauth';
 import { warnLog, errorLog } from '@/utils/logger';
 import { sendTemplateApply, sendTemplateCreateStart, sendTemplateDelete } from '@/utils/analytics';
@@ -192,7 +193,9 @@ export const TemplateListPage = () => {
 
       // 6. 기본 템플릿 추가 (항상 맨 위에 표시)
       // Convert LinkList to Icon array (including lucide-react icons)
-      const defaultIcons = LinkList.map((link, index) => {
+      const latestBulletin = await resolveLatestBulletin();
+      const defaultLinks = createLinkList(latestBulletin);
+      const defaultIcons = defaultLinks.map((link, index) => {
         let imageUrl: string;
 
         if (typeof link.icon === 'string') {
@@ -209,7 +212,10 @@ export const TemplateListPage = () => {
           imageUrl,
         };
       });
-      const defaultTemplateItems = convertLinkListToTemplateItems(defaultIcons);
+      const defaultTemplateItems = convertLinkListToTemplateItems(
+        defaultIcons,
+        defaultLinks,
+      );
       const defaultTemplate: TemplateSummary = {
         templateId: 0,
         name: 'LinKU 기본 템플릿',

--- a/src/pages/TemplateListPage.tsx
+++ b/src/pages/TemplateListPage.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getOwnedTemplates, getClonedTemplates, deleteTemplate, getTemplate } from '@/apis/templates';
 import type { TemplateSummary, PostedTemplateSummary } from '@/types/api';
+import type { BulletinInfo } from '@/constants/bulletin';
 
 // Extended type with needsSync flag
 interface TemplateSummaryWithSync extends TemplateSummary {
@@ -28,7 +29,10 @@ import { useSelectedTemplate } from '@/hooks/useSelectedTemplate';
 import { usePostedTemplates } from '@/hooks/usePostedTemplates';
 import { useTemplateSync } from '@/hooks/useTemplateSync';
 import { useTemplatePublish } from '@/hooks/useTemplatePublish';
-import { resolveLatestBulletin } from '@/apis/external/bulletin';
+import {
+  resolveLatestBulletin,
+  subscribeLatestBulletin,
+} from '@/apis/external/bulletin';
 import { getTemplatesIndex, loadTemplateFromLocalStorage, deleteTemplateFromLocalStorage } from '@/utils/templateStorage';
 import { getErrorMessage } from '@/utils/apiErrorHandler';
 import { convertLinkListToTemplateItems, convertLucideIconToDataUri } from '@/utils/template';
@@ -37,6 +41,32 @@ import { createDefaultLinkList } from '@/constants/LinkList';
 import { isLoggedIn } from '@/utils/oauth';
 import { warnLog, errorLog } from '@/utils/logger';
 import { sendTemplateApply, sendTemplateCreateStart, sendTemplateDelete } from '@/utils/analytics';
+
+function createDefaultTemplate(bulletin: BulletinInfo): TemplateSummary {
+  const defaultLinks = createDefaultLinkList(bulletin);
+  const defaultIcons = defaultLinks.map((link, index) => ({
+    id: index,
+    name: link.label,
+    imageUrl:
+      typeof link.icon === 'string'
+        ? link.icon
+        : convertLucideIconToDataUri(link.icon),
+  }));
+  const items = convertLinkListToTemplateItems(defaultIcons, defaultLinks);
+  const timestamp = new Date().toISOString();
+
+  return {
+    templateId: 0,
+    name: 'LinKU 기본 템플릿',
+    height: 6,
+    cloned: false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    itemCount: items.length,
+    syncStatus: 'synced',
+    items,
+  };
+}
 
 export const TemplateListPage = () => {
   const navigate = useNavigate();
@@ -66,6 +96,18 @@ export const TemplateListPage = () => {
   useEffect(() => {
     toastRef.current = toast;
   }, [toast]);
+
+  useEffect(
+    () =>
+      subscribeLatestBulletin((bulletin) => {
+        setOwnedTemplates((templates) =>
+          templates[0]?.templateId === 0
+            ? [createDefaultTemplate(bulletin), ...templates.slice(1)]
+            : templates,
+        );
+      }),
+    [],
+  );
 
   const loadTemplates = useCallback(async () => {
     setLoading(true);
@@ -192,41 +234,8 @@ export const TemplateListPage = () => {
       }
 
       // 6. 기본 템플릿 추가 (항상 맨 위에 표시)
-      // Convert LinkList to Icon array (including lucide-react icons)
       const latestBulletin = await resolveLatestBulletin();
-      const defaultLinks = createDefaultLinkList(latestBulletin);
-      const defaultIcons = defaultLinks.map((link, index) => {
-        let imageUrl: string;
-
-        if (typeof link.icon === 'string') {
-          // PNG/URL 문자열
-          imageUrl = link.icon;
-        } else {
-          // LucideIcon 컴포넌트 → 데이터 URI 변환
-          imageUrl = convertLucideIconToDataUri(link.icon);
-        }
-
-        return {
-          id: index,
-          name: link.label,
-          imageUrl,
-        };
-      });
-      const defaultTemplateItems = convertLinkListToTemplateItems(
-        defaultIcons,
-        defaultLinks,
-      );
-      const defaultTemplate: TemplateSummary = {
-        templateId: 0,
-        name: 'LinKU 기본 템플릿',
-        height: 6,
-        cloned: false,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        itemCount: defaultTemplateItems.length,
-        syncStatus: 'synced',
-        items: defaultTemplateItems,
-      };
+      const defaultTemplate = createDefaultTemplate(latestBulletin);
 
       // 7. 최종 정렬 (updatedAt 기준 내림차순)
       mergedOwned.sort((a, b) => {

--- a/src/pages/TemplateListPage.tsx
+++ b/src/pages/TemplateListPage.tsx
@@ -33,7 +33,7 @@ import { getTemplatesIndex, loadTemplateFromLocalStorage, deleteTemplateFromLoca
 import { getErrorMessage } from '@/utils/apiErrorHandler';
 import { convertLinkListToTemplateItems, convertLucideIconToDataUri } from '@/utils/template';
 import { areItemsEqual } from '@/utils/templateUtils';
-import { createLinkList } from '@/constants/LinkList';
+import { createDefaultLinkList } from '@/constants/LinkList';
 import { isLoggedIn } from '@/utils/oauth';
 import { warnLog, errorLog } from '@/utils/logger';
 import { sendTemplateApply, sendTemplateCreateStart, sendTemplateDelete } from '@/utils/analytics';
@@ -194,7 +194,7 @@ export const TemplateListPage = () => {
       // 6. 기본 템플릿 추가 (항상 맨 위에 표시)
       // Convert LinkList to Icon array (including lucide-react icons)
       const latestBulletin = await resolveLatestBulletin();
-      const defaultLinks = createLinkList(latestBulletin);
+      const defaultLinks = createDefaultLinkList(latestBulletin);
       const defaultIcons = defaultLinks.map((link, index) => {
         let imageUrl: string;
 

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -5,7 +5,8 @@
  */
 
 import type { TemplateItem, TemplateIcon, Icon, Position, Size } from '@/types/api';
-import { LinkList } from '@/constants/LinkList';
+import { LinkList, type LinkListElement } from '@/constants/LinkList';
+import { BULLETIN_LINK_ID } from '@/constants/bulletin';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { LucideIcon } from 'lucide-react';
@@ -106,8 +107,12 @@ export function clampToGridBounds(position: Position, size: Size): Position {
 /**
  * Calculate grid position for LinkList item
  */
-function calculateGridPosition(index: number, colSpan: number): { x: number; y: number } {
-  const items = LinkList.map((item, i) => ({
+function calculateGridPosition(
+  index: number,
+  colSpan: number,
+  linkList: LinkListElement[],
+): { x: number; y: number } {
+  const items = linkList.map((item, i) => ({
     index: i,
     colSpan: item.islong ? 3 : 2,
   }));
@@ -152,7 +157,7 @@ function calculateGridSize(colSpan: number): { width: number; height: number } {
  * For Lucide icons, use the component's displayName
  * For string/PNG icons, use the label
  */
-function getIconIdentifier(linkItem: typeof LinkList[number]): string {
+function getIconIdentifier(linkItem: LinkListElement): string {
   const icon = linkItem.icon;
 
   // If icon is a Lucide component, try to get its name
@@ -172,7 +177,7 @@ function getIconIdentifier(linkItem: typeof LinkList[number]): string {
  * Map LinkList icon to default icon using multiple matching strategies
  * Returns null if no valid server icon is found
  */
-function findMatchingIcon(linkItem: typeof LinkList[number], defaultIcons: Icon[]): Icon | null {
+function findMatchingIcon(linkItem: LinkListElement, defaultIcons: Icon[]): Icon | null {
   // Ensure defaultIcons is an array with valid server icons
   if (!Array.isArray(defaultIcons) || defaultIcons.length === 0) {
     warnLog('findMatchingIcon: No server icons available');
@@ -228,7 +233,8 @@ function findMatchingIcon(linkItem: typeof LinkList[number], defaultIcons: Icon[
       '창업지원': 'lightbulb',
     };
 
-    const mappedIconName = labelToIconMap[label];
+    const mappedIconName =
+      linkItem.id === BULLETIN_LINK_ID ? 'scroll' : labelToIconMap[label];
     if (mappedIconName) {
       match = defaultIcons.find(icon =>
         icon.name.toLowerCase().includes(mappedIconName)
@@ -250,7 +256,10 @@ function findMatchingIcon(linkItem: typeof LinkList[number], defaultIcons: Icon[
  * Convert LinkList to TemplateItems with grid coordinates
  * Only includes items with valid server icons
  */
-export function convertLinkListToTemplateItems(defaultIcons: Icon[]): TemplateItem[] {
+export function convertLinkListToTemplateItems(
+  defaultIcons: Icon[],
+  linkList: LinkListElement[] = LinkList,
+): TemplateItem[] {
   // Validate that defaultIcons is an array
   if (!Array.isArray(defaultIcons)) {
     errorLog('convertLinkListToTemplateItems: defaultIcons is not an array', defaultIcons);
@@ -264,7 +273,7 @@ export function convertLinkListToTemplateItems(defaultIcons: Icon[]): TemplateIt
 
   const items: TemplateItem[] = [];
 
-  LinkList.forEach((linkItem, index) => {
+  linkList.forEach((linkItem, index) => {
     // Find matching server icon
     const icon = findMatchingIcon(linkItem, defaultIcons);
 
@@ -275,7 +284,7 @@ export function convertLinkListToTemplateItems(defaultIcons: Icon[]): TemplateIt
     }
 
     const colSpan = linkItem.islong ? 3 : 2;
-    const position = calculateGridPosition(index, colSpan);
+    const position = calculateGridPosition(index, colSpan, linkList);
     const size = calculateGridSize(colSpan);
 
     items.push({

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -112,17 +112,12 @@ function calculateGridPosition(
   colSpan: number,
   linkList: LinkListElement[],
 ): { x: number; y: number } {
-  const items = linkList.map((item, i) => ({
-    index: i,
-    colSpan: item.islong ? 3 : 2,
-  }));
-
   let currentCol = 0;
   let currentRow = 0;
 
   // Find position for this index
   for (let i = 0; i < index; i++) {
-    const itemColSpan = items[i].colSpan;
+    const itemColSpan = linkList[i].islong ? 3 : 2;
 
     // Check if item fits in current row
     if (currentCol + itemColSpan > GRID_CONFIG.COLS) {
@@ -228,7 +223,6 @@ function findMatchingIcon(linkItem: LinkListElement, defaultIcons: Icon[]): Icon
       '학과 정보': 'users',
       '쿨하우스': 'bed',
       'kung': 'message',
-      '요람': 'scroll',
       '현장실습': 'building',
       '창업지원': 'lightbulb',
     };


### PR DESCRIPTION
## 요약

- 건국대학교 요람 기본 링크를 2026 요람으로 갱신합니다.
- 저장된 검증 연도를 먼저 렌더링하고, 현재 연도와 직전 연도는 UI를 막지 않는 백그라운드 작업으로 확인합니다.
- 최종 URL과 HTTP 상태뿐 아니라 실제 화면 텍스트의 건국대학교 요람 제목까지 확인된 경우에만 버튼 연도와 URL을 함께 갱신합니다.
- 검증 결과는 `verified / unverified` 두 상태로 유지하며, 검증되지 않은 응답은 기존 요람을 유지한 채 7일 후 다시 확인합니다.
- 기본 링크, 기본 템플릿 미리보기, 기본값으로 새로 만드는 템플릿에 같은 캐시를 사용합니다. 저장된 사용자 템플릿은 변경하지 않습니다.
- GitHub Release 설치 안내에 Chrome 웹 스토어 링크와 로컬 설치 방법을 분리하고, 릴리스 workflow를 Node 24 호환 action과 frozen lockfile 기반으로 정리합니다.

## 런타임 구조

```mermaid
flowchart LR
    subgraph UI["UI 소비 계층"]
        Initial["2026 fallback 또는<br/>저장된 검증 연도"]
        Main["메인 기본 링크"]
        Preview["기본 템플릿 미리보기"]
        Editor["기본 템플릿 생성"]
        Custom["저장된 사용자 템플릿"]
    end

    subgraph Bulletin["요람 도메인"]
        Resolver["resolveLatestBulletin()"]
        Cache["Chrome local storage<br/>resolvedYear · attemptedYear · checkedAt"]
        Refresh["세션 중복 제거된<br/>백그라운드 재검증"]
        Probe["현재 연도 + 직전 연도<br/>병렬 검사"]
        Verify{"200 + 예상 URL +<br/>실제 요람 제목"}
        Notify["캐시 저장 + 구독 알림"]
        Factory["createDefaultLinkList()"]
    end

    Site["건국대학교 연도별 요람<br/>bulletinsYY/index.do"]

    Initial --> Main
    Initial --> Preview
    Main --> Resolver
    Preview --> Resolver
    Editor --> Resolver
    Resolver --> Cache
    Cache -->|"즉시 반환"| Factory
    Factory --> Main
    Factory --> Preview
    Factory --> Editor
    Cache -->|"7일 경과 또는 새 연도"| Refresh
    Refresh --> Probe
    Probe --> Site
    Site --> Verify
    Verify -->|"verified 중 가장 높은 연도"| Notify
    Verify -->|"모두 unverified"| Cache
    Notify --> Cache
    Notify --> Main
    Notify --> Preview
    Custom -->|"자동 변경 없음"| Main
```

요람 resolver는 stale-while-revalidate 방식으로 동작합니다. Chrome storage에서 읽은 기존 검증 연도를 네트워크보다 먼저 반환하고, 재검사가 필요할 때만 뒤에서 요청합니다. 여러 화면이 동시에 resolver를 호출해도 한 세션에서는 동일한 재검증을 공유합니다.

메인 기본 링크와 기본 템플릿 미리보기는 갱신 이벤트를 구독하므로 새 연도가 검증되면 현재 화면에서 교체됩니다. 새 편집 초안은 생성 시점의 최신 캐시를 사용하되, 사용자가 편집을 시작한 뒤 백그라운드에서 내용을 변경하지는 않습니다.

사이트맵은 공식 경로를 탐색하고 현재 요람을 확인하는 근거로만 사용했습니다. 런타임은 사이트맵 HTML 구조나 WAF 동작에 의존하지 않고 연도별 주소를 직접 검증합니다.

## 판정 상태

```mermaid
stateDiagram-v2
    [*] --> ReadCache
    ReadCache --> RenderCached: 저장된 검증 연도
    ReadCache --> RenderFallback: storage 없음 또는 오류
    RenderCached --> Done: 현재 연도 검증 완료
    RenderCached --> Done: 최근 7일 이내 검사
    RenderCached --> ParallelProbe: 백그라운드 재검사

    state ParallelProbe {
        [*] --> ProbeCurrent
        [*] --> ProbePrevious
        ProbeCurrent --> [*]
        ProbePrevious --> [*]
    }

    ParallelProbe --> SaveNewYear: verified 존재
    ParallelProbe --> KeepPrevious: 모두 unverified
    SaveNewYear --> NotifyUI
    NotifyUI --> Done
    KeepPrevious --> SaveCheckedAt
    SaveCheckedAt --> Done
    RenderFallback --> Done
```

- `verified`: 최종 URL, HTTP 200과 함께 화면 텍스트에서 `2027 건국대학교 요람` 또는 `2027학년도 건국대학교 온라인요람` 형태를 확인합니다.
- `unverified`: 404, 관리모드 오류, SSO 로그인, WAF, 타임아웃, canonical URL만 있는 placeholder, 예상하지 않은 HTML을 모두 포함합니다.
- 현재 연도와 직전 연도는 병렬 검사합니다. 둘 다 최대 시간까지 지연돼도 UI는 이미 캐시를 표시하며, 백그라운드 검사 자체도 최대 약 5초로 제한됩니다.
- 두 후보가 모두 검증되면 연도가 높은 현재 연도를 선택합니다.

## 릴리스 흐름

```mermaid
flowchart LR
    Push["main push"] --> Version["manifest 버전 확인"]
    Version --> Tag["원격 태그 정확히 조회"]
    Tag -->|"기존 태그"| Skip["릴리스 생략"]
    Tag -->|"새 버전"| Install["Node 24 · pnpm<br/>frozen lockfile"]
    Install --> Build["확장 프로그램 빌드"]
    Build --> Zip["dist.zip 생성"]
    Zip --> Release["GitHub Release 생성"]
    Release --> Store["Chrome 웹 스토어 설치 링크"]
    Release --> Local["로컬 설치 방법"]
    Release --> Notes["자동 변경 내역"]
```

## 검증

- [x] `pnpm run lint`
- [x] `pnpm run build:local`
- [x] `actionlint .github/workflows/create-release.yml`
- [x] workflow YAML parse
- [x] `git diff --check`
- [x] stale-while-revalidate smoke scenarios
  - 네트워크 응답이 보류돼도 저장된 2026이 즉시 반환됨
  - 2028과 2027 후보 요청이 동시에 시작됨
  - canonical URL만 있는 2028 placeholder는 거부됨
  - 실제 `2027 건국대학교 요람` 제목이 있는 2027만 캐시와 구독 UI에 반영됨
  - 갱신된 캐시는 추가 요청 없이 재사용됨
- [x] 2026 요람 실제 브라우저 응답 확인
  - title: `2026 건국대학교 요람`
  - body: `2026학년도 건국대학교 온라인요람`
- [x] 2027 후보 주소가 실제 요람이 아니라 `관리모드 > 알림메세지`인 것 확인

`chrome://extensions` unpacked-extension 로드는 자동화 브라우저의 보안 정책으로 실행하지 못했습니다. 실제 학교 페이지 응답과 빌드 산출물은 각각 검증했습니다.

## 영향 범위

- manifest version 변경 없음
- permission 및 host permission 변경 없음
- 저장된 사용자 템플릿 변경 없음
- 새 상태 관리 또는 데이터 fetching dependency 추가 없음
- 기존 Vite의 React SWC `esbuild` 폐기 예정 경고와 500 kB 초과 bundle 경고는 이번 변경과 무관합니다.
