### PR TITLE
fix(ci): update Chrome Web Store authentication inputs

### DIFF
--- a/.github/workflows/upload-chrome-extension-draft.yml
+++ b/.github/workflows/upload-chrome-extension-draft.yml
@@ -47,13 +47,14 @@ jobs:
         run: npm install --global chrome-webstore-upload-cli@4.0.1
 
       - name: Upload to Chrome Web Store (Draft only)
+        env:
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
         run: |
           chrome-webstore-upload upload \
             --source extension.zip \
-            --extension-id ${{ secrets.CHROME_EXTENSION_ID }} \
-            --client-id ${{ secrets.CHROME_CLIENT_ID }} \
-            --client-secret ${{ secrets.CHROME_CLIENT_SECRET }} \
-            --refresh-token ${{ secrets.CHROME_REFRESH_TOKEN }}
+            --extension-id ${{ secrets.CHROME_EXTENSION_ID }}
 
       - name: Commit and push version update
         run: |


### PR DESCRIPTION
## 요약

- `chrome-webstore-upload-cli@4.0.1`에서 제거된 OAuth credential flags를 사용하지 않도록 수정합니다.
- `CLIENT_ID`, `CLIENT_SECRET`, `REFRESH_TOKEN`을 GitHub Actions `env`로 전달합니다.
- 계속 지원되는 `--extension-id`와 `--source`만 CLI 인자로 유지합니다.

## 원인

PR #75 merge 후 [Upload Chrome Extension Draft run](https://github.com/Turtle-Hwan/LinKU/actions/runs/30875234013)에서 CLI 4.0.1이 `--client-id`, `--client-secret`, `--refresh-token`을 거부했습니다.

## 검증

- workflow YAML 파싱 통과
- `chrome-webstore-upload-cli@4.0.1 --help`에서 credential environment variables와 `--extension-id` 지원 확인
- `git diff --check` 통과
