### PR TITLE
feat: import Everytime timetables into the popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ pnpm install
 pnpm run dev
 pnpm run build:local
 pnpm run lint
+pnpm run test:timetable
 ```
 
 Chrome에서 확장 프로그램을 검증하기 전에는 `pnpm run build:local`을 실행하고,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,12 @@ LinKU는 건국대학교 학생을 위한 Manifest V3 Chrome Extension입니다.
 - Root app shell: `src/App.tsx`
 - Background service worker: `src/background/index.ts`
 - OAuth handler: `src/background/handlers/oauth.ts`
+- Everytime timetable content script: `src/content/everytime-timetable.ts`
 - Extension manifest: `public/manifest.json`
 
-현재 구조에는 content script가 없습니다. `public/manifest.json`이 변경되지 않는
-한 페이지 주입 기능이 존재한다고 가정하지 마세요.
+content script는 에브리타임 시간표 HTML 파싱에만 사용됩니다. 새 페이지 주입
+기능을 추가할 때는 `public/manifest.json`의 구체적인 match pattern과 데이터
+경계를 함께 검토하세요.
 
 ## 공통 명령
 
@@ -64,6 +66,20 @@ Chrome에서 확장 프로그램을 검증하기 전에는 `pnpm run build:local
 - 이미 working tree에 존재하는 사용자 변경사항을 보존하세요. 편집 전
   `git status`를 확인하세요.
 
+## 컴포넌트 조합 규칙
+
+- 로딩·빈 상태·저장 후 상태·다이얼로그처럼 하나의 feature가 여러 화면 역할로
+  나뉘면, compound component를 기본으로 사용하세요. 예: `TimeTable.Loading`,
+  `TimeTable.Empty`, `TimeTable.Saved`.
+- root component는 상태, side effect, 이벤트 연결을 담당하고, 하위 component는
+  역할이 드러나는 이름과 명시적인 props로 화면을 담당합니다. root의 긴 조건부
+  JSX와 중복 action UI를 줄이는 것이 목적입니다.
+- 외부 consumer가 하위 component를 조합해야 한다면 `Object.assign` 등으로
+  export된 component에도 정적 멤버를 보존하세요. 한 파일 안에서만 조합한다면
+  기존 `MainLayout.Header`, `LinkGroup.Grid` 관례를 따릅니다.
+- 단일 역할의 작고 독립적인 UI까지 compound component로 감싸지는 마세요.
+  독립 재사용이 필요한 경우에는 일반 component를 우선합니다.
+
 ## 소스 책임 지도
 
 - `src/components/Tabs/`: popup tab 기능.
@@ -87,6 +103,14 @@ Chrome에서 확장 프로그램을 검증하기 전에는 `pnpm run build:local
 - `.github/workflows/`: Chrome Web Store upload, GitHub Pages, release 흐름을
   제어합니다.
 - `src/background/handlers/oauth.ts`: auth flow와 token handling을 담당합니다.
+- `src/background/handlers/timetable.ts`: Everytime tab 탐색, 로그인 재개,
+  수동 학기 묶음 import orchestration을 담당합니다.
+- `src/content/everytime-timetable.ts`: Everytime 시간표 XML을 구조화하고 API
+  실패 시 DOM을 파싱하며 password, cookie, session token은 읽거나 저장하지 않습니다.
+- `src/utils/everytimeTimetable.ts`: Everytime 원본 snapshot과 사용자 override를
+  병합하는 side-effect 없는 도메인 로직을 담당합니다.
+- `src/utils/timetableStorage.ts`: snapshot asset과 별도 override index의 저장,
+  schema migration, 삭제 시 정리를 담당합니다.
 - `src/apis/client.ts`: auth interceptor, backend response parsing,
   silent reauth를 담당합니다.
 - `src/apis/external/`: third-party 또는 school page markup에 의존하는 parsing
@@ -109,4 +133,3 @@ TypeScript, React hooks, shared utilities, CI/lint configuration을 수정했다
 UI 또는 확장 프로그램 동작을 변경했다면 `dist/`를 Chrome에 직접 로드해 관련
 popup 흐름을 검증하세요. OAuth, storage, badge, service-worker 변경은 Vite
 dev mode와 실제 extension runtime이 다르므로 브라우저 검증이 필요합니다.
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,357 +1,105 @@
 # 아키텍처
 
-이 문서는 LinKU가 런타임에서 어떻게 구성되는지, 그리고 어느 위치를 어떻게
-수정해야 안전한지 설명합니다.
+이 문서는 LinKU의 런타임 경계와 데이터 흐름만 설명합니다. 실행·기여 규칙은
+`docs/CONTRIBUTING.md`, 에이전트 진입점은 `AGENTS.md`를 따릅니다.
 
-## 시스템 개요
+## 런타임
 
-LinKU는 Vite, React, TypeScript, Tailwind CSS로 만든 Manifest V3 Chrome
-Extension입니다. 확장 프로그램은 세 개의 런타임 영역을 가집니다.
+LinKU는 Vite, React, TypeScript로 만든 Manifest V3 Chrome Extension이며 세
+영역으로 실행됩니다.
 
-- `index.html`에서 렌더링되는 Popup UI.
-- `src/background/index.ts`에서 빌드되는 Background service worker.
-- `src/content/everytime-timetable.ts`에서 빌드되어 에브리타임 시간표
-  페이지에서만 실행되는 content script.
+- Popup UI: `index.html` → `src/main.tsx` → `src/routes.tsx`.
+- Background service worker: `src/background/index.ts`.
+- Everytime content script: `src/content/everytime-timetable.ts`.
 
-대부분의 user interaction은 popup 내부에서 일어납니다. content script는
-로그인된 에브리타임 탭에서 시간표 XML API를 호출하고, API를 사용할 수 없을 때만
-렌더링된 시간표 DOM을 구조화해 읽습니다. 브라우저가 요청에 기존 로그인 쿠키를
-자동으로 포함하지만 LinKU는 password, cookie, session token을 직접 읽거나
-저장하지 않습니다.
+popup은 화면과 사용자 입력을 담당하고, OAuth·badge·시간표 import처럼 extension
+API가 필요한 작업은 background worker가 담당합니다. content script는
+`https://everytime.kr/timetable*`에서만 실행됩니다.
 
-## Backend 의존성
+extension build는 다음 entry를 `dist/`에 생성합니다.
 
-LinKU는 frontend-only extension이 아닙니다. auth, template sync, posted
-template, icons, alerts 같은 backend 연동 기능은 `VITE_API_BASE_URL`이
-올바르게 설정되어야 동작합니다.
+- `index.html`
+- `background/index.js`
+- `content/everytime-timetable.js`
 
-로컬 개발 환경에서 `VITE_API_BASE_URL`이 없거나 placeholder 값으로 남아
-있다면, 다음 기능은 정상적으로 동작하지 않을 수 있습니다.
+로컬 검증에는 version을 올리지 않는 `pnpm run build:local`을 사용합니다.
 
-- Google OAuth login
-- template sync와 posted-template API
-- icons API
-- alerts subscription API
-- `src/apis/` 아래 LinKU backend를 호출하는 기타 기능
+## 소스 경계
 
-## 빌드 모델
+- `src/pages/`, `src/layouts/`: route와 layout.
+- `src/components/Tabs/`: popup feature.
+- `src/components/ui/`: 공통 UI primitive.
+- `src/components/Editor/`: template editor.
+- `src/contexts/`, `src/hooks/`: React state와 reusable hook.
+- `src/apis/`: LinKU backend client.
+- `src/apis/external/`: 학교·외부 서비스 연동.
+- `src/background/`: MV3 service worker와 message handler.
+- `src/content/`: 허용된 외부 페이지 content script.
+- `src/types/`, `src/utils/`: 공유 contract와 cross-cutting utility.
 
-`vite.config.ts`는 extension mode에서 multi-entry build를 설정합니다.
+## 주요 데이터 흐름
 
-- `index.html`은 popup entry가 됩니다.
-- `src/background/index.ts`는 `background/index.js`가 됩니다.
-- `src/content/everytime-timetable.ts`는
-  `content/everytime-timetable.js`가 됩니다.
+### Backend와 인증
 
-`gh-pages` mode에서는 build output이 `gh-pages/`로 바뀌고, static hosting을
-위해 banner asset이 복사됩니다. extension build의 output directory는
-`dist/`입니다.
+`src/apis/client.ts`가 `VITE_API_BASE_URL`을 기준으로 backend 요청, bearer token,
+response parsing, 만료 감지를 중앙 처리합니다. Google OAuth는
+`src/background/handlers/oauth.ts`에서 `chrome.identity.launchWebAuthFlow`를
+사용하며 token은 `chrome.storage.local`에 저장합니다.
 
-중요한 script:
-
-```bash
-pnpm run dev
-pnpm run build:local
-pnpm run build
-pnpm run watch:local
-pnpm run build:gh-pages
-```
-
-`pnpm run build`는 build 전에 manifest patch version을 증가시킵니다. local
-validation에서 version bump를 원하지 않는다면 `pnpm run build:local`을
-사용하세요.
-
-## 런타임 진입점
-
-Popup UI 흐름:
-
-```text
-index.html
-  -> src/main.tsx
-  -> src/routes.tsx
-  -> src/App.tsx
-  -> route pages and layouts
-```
-
-Background worker 흐름:
-
-```text
-public/manifest.json
-  -> background.service_worker: background/index.js
-  -> src/background/index.ts
-  -> src/background/handlers/oauth.ts
-  -> src/background/handlers/timetable.ts
-```
-
-Everytime import 흐름:
-
-```text
-public/manifest.json
-  -> content_scripts.matches: https://everytime.kr/timetable*
-  -> src/content/everytime-timetable.ts
-  -> Everytime semester/table XML API (rendered DOM fallback)
-  -> chrome.runtime message
-  -> src/background/handlers/timetable.ts
-  -> chrome.storage.local structured timetable collection
-```
-
-popup은 React Router의 hash routing을 사용합니다. Chrome extension popup
-page는 일반적인 server-backed web route처럼 동작하지 않기 때문에 hash routing을
-사용합니다.
-
-## 라우트
-
-route는 `src/routes.tsx`에 정의되어 있습니다.
-
-- `/`: `MainLayout` 안의 main popup page.
-- `/editor`: 새 template editor.
-- `/editor/:templateId`: 기존 template editor.
-- `/templates`: owned/local template list.
-- `/gallery`: public posted-template gallery.
-- `*`: not found page.
-
-`src/App.tsx`는 root error boundary, global providers, page-view analytics,
-toast rendering을 제공합니다.
-
-## 소스 구조
-
-```text
-src/
-  apis/          LinKU backend API wrapper
-  apis/external/ 학교 또는 외부 서비스 integration
-  assets/        local image와 SVG asset
-  background/    Manifest V3 service worker code
-  components/    feature component와 UI primitive
-  content/       제한된 외부 페이지 content script
-  constants/     정적 app data
-  contexts/      React Context 상태 container
-  hooks/         reusable React hook
-  layouts/       route layout wrapper
-  pages/         route 단위 screen
-  types/         공유 TypeScript contract
-  utils/         storage, auth, analytics, template, Chrome helper
-```
-
-## 주요 기능 영역
-
-기본 popup 기능:
-
-- Link groups: `src/components/Tabs/LinkGroup.tsx`
-- Banners: `src/components/Tabs/ImageCarousel.tsx`
-- Todo list: `src/components/Tabs/TodoList/`
-- Alerts: `src/components/Tabs/Alerts/`
-- Timetable: `src/components/Tabs/TimeTable/`
-- Labs: `src/components/Labs/`
-
-Template system 구성:
-
-- Editor page: `src/pages/EditorPage.tsx`
-- Template list: `src/pages/TemplateListPage.tsx`
-- Public gallery: `src/pages/GalleryPage.tsx`
-- Editor state: `src/contexts/EditorContext.tsx`
-- Editor UI: `src/components/Editor/`
-- Local template persistence: `src/utils/templateStorage.ts`
-- Template helper: `src/utils/template.ts`
-
-Auth 및 account 관련 UI:
-
-- OAuth popup/background bridge: `src/utils/oauth.ts`
-- Background OAuth handler: `src/background/handlers/oauth.ts`
-- Background timetable handler: `src/background/handlers/timetable.ts`
-- API auth interceptor: `src/apis/client.ts`
-- Email verification dialog: `src/components/EmailVerificationDialog.tsx`
-- Settings dialog: `src/components/SettingsDialog.tsx`
-
-## Popup과 Background 통신
-
-popup은 `chrome.runtime.sendMessage`를 사용해 background service worker와
-통신합니다.
-
-message type과 guard는 `src/background/types.ts`에 있습니다.
-
-background worker가 처리하는 일:
-
-- Google login request.
-- Silent reauth request.
-- User-triggered Everytime timetable import request.
-- Extension install/update event.
-- Badge count initialization.
-- `chrome.storage.local` 변경에 따른 badge count update.
-
-OAuth는 background worker에 있습니다. `chrome.identity.launchWebAuthFlow`는
-일반 browser page flow가 아니라 extension API로 다뤄야 하기 때문입니다.
-
-## Backend API 흐름
-
-중앙 HTTP client는 `src/apis/client.ts`입니다.
-
-주요 책임:
-
-- `VITE_API_BASE_URL`에서 backend URL을 구성합니다.
-- `chrome.storage.local`의 bearer token을 request에 붙입니다.
-- backend response envelope을 parsing합니다.
-- token-expired backend code `5004`를 감지합니다.
-- background worker에 silent reauth를 요청합니다.
-- silent reauth 성공 후 original request를 한 번 retry합니다.
-- hard auth failure에서 `auth:unauthorized`를 dispatch합니다.
-
-feature-specific API module은 fetch behavior를 중복 구현하지 말고 이 client를
-사용해야 합니다.
-
-## Storage 모델
-
-현재 storage는 세 browser storage system으로 나뉘어 있습니다.
-
-- `chrome.storage.local`: auth token, user profile state, settings, custom
-  todo, library token, badge count, timetable metadata.
-- `localStorage`: `src/utils/templateStorage.ts`를 통한 template draft와 local
-  template persistence.
-- IndexedDB: 사용자가 직접 업로드한 PNG, JPG/JPEG, WebP, GIF, AVIF timetable
-  이미지 blob만 저장합니다. 이미지와 metadata index를 분리해 향후 backend
-  sync를 붙일 수 있도록 metadata에 schema version과 sync status를 둡니다.
-- `chrome.storage.local`: 에브리타임 원본 snapshot은 `timetableAssetIndex`의
-  schema v3 asset에, 사용자 수정은 별도 `timetableEverytimeOverrides`의 schema
-  v1 index에 저장합니다. 조회할 때만 `src/utils/everytimeTimetable.ts`가 두 층을
-  병합합니다. 동기화는 snapshot만 갱신하므로 사용자 수정 저장소를 덮지 않습니다.
-  원본 HTML, password, cookie, session token은 저장하지 않습니다.
-
-이 분리는 과거 설계의 결과입니다. template local persistence flow를 직접
-수정하는 경우가 아니라면, 새 extension-wide state는 `chrome.storage.local`을
-우선 사용하세요.
-
-stored data shape를 바꿀 때는 기존 user의 migration behavior를 고려해야
-합니다. LinKU는 실제 user에게 배포되는 extension이므로 가능한 한 backward
-compatible해야 합니다. 시간표 asset schema v2는 처음 읽을 때 v3 snapshot
-구조로 자동 변환합니다.
-
-## 인증
-
-Google OAuth flow는 backend-mediated flow입니다.
-
-1. popup이 background worker에 login 시작을 요청합니다.
-2. background worker가 extension redirect URI를 계산합니다.
-3. background worker가 `chrome.identity.launchWebAuthFlow`로 backend Google
-   OAuth URL을 엽니다.
-4. backend가 auth code를 포함해 redirect합니다.
-5. background worker가 backend를 통해 code를 token으로 교환합니다.
-6. token은 `chrome.storage.local`에 저장됩니다.
-7. popup/API state가 auth success 또는 failure에 반응합니다.
-
-auth code, access token, refresh token, full token response를 로그로 남기지
-마세요.
-
-## 외부 연동
-
-`src/apis/external/`에는 이 repository가 소유하지 않는 integration이 있습니다.
-예시는 eCampus, library, banners, RSS, HTML parsing입니다.
-
-이 module들은 external service의 response shape 또는 DOM structure가 바뀌면
-깨질 수 있습니다. 이 영역의 변경은 PR에 manual verification notes를 포함해야
-합니다.
-
-### 공지 캐시와 동기화
-
-공개 공지는 backend가 아니라 건국대학교의 카테고리별 RSS 5개와 취창업 HTML
-목록 1개에서 가져옵니다. `src/apis/public-alert-cache.ts`는 이 여섯 source를
-`chrome.storage.local`의 `publicAlertCacheV1:<source>` 키에 각각 저장합니다.
-
-```mermaid
-flowchart LR
-  UI["공지 탭 또는 카테고리 선택"] --> Cache["source별 로컬 캐시"]
-  Cache -->|"즉시 표시"| UI
-  Cache --> Fresh{"10분 TTL 이내?"}
-  Fresh -->|"예"| Stop["학교 서버 호출 없음"]
-  Fresh -->|"아니요"| Source["선택한 RSS 또는 취창업 HTML"]
-  Source --> Merge["안정 URL로 병합"]
-  Merge --> Cache
-```
-
-- 전체 화면은 만료된 source만 갱신하고, 카테고리 화면은 선택한 source만
-  갱신합니다.
-- 첫 동기화는 최신 한 페이지만 저장합니다. 이후 동기화는 직전 첫 페이지의
-  끝부분을 기준점으로 삼아, 기준점을 다시 만날 때까지 다음 페이지를 읽습니다.
-- 여러 페이지를 읽은 경우 첫 페이지를 다시 확인합니다. 읽는 도중 목록이
-  바뀌었다면 한 번 다시 시작하며, 완전한 경계를 확인하지 못한 결과는 저장하지
-  않습니다.
-- 동일 공지는 정규화된 URL로 병합하고, 실패한 source는 기존 캐시와 기준점을
-  유지해 다음 화면 진입에서 다시 시도합니다.
-- `chrome.storage.local` 용량을 잠식하지 않도록 source별 최신 500개까지만
-  보존합니다.
-- popup이 닫힌 동안 실행되는 background alarm은 없습니다. 캐시가 만료된 뒤
-  사용자가 공지 화면을 열거나 카테고리를 바꿀 때만 network sync가 일어납니다.
-
-학교 접근은 `fetchPublicAlertPage` 한 함수에 모여 있어 중앙 수집기가 생기면 이
-경계만 교체할 수 있습니다. 단, frontend-only 구조에서는 학교가
-게시물을 source에서 제거하거나 local storage가 삭제된 기간까지 절대적인 무누락을
-보장할 수 없으며, 현재 공개된 목록 안에서 확인 가능한 동기화 경계만 보존합니다.
+feature API는 이 client와 background 경계를 재사용해야 합니다. auth code,
+token, authorization header를 로그에 남기지 않습니다.
 
 ### Everytime 시간표
 
-사용자가 popup에서 가져오기를 누르면 background worker는 이미 열린
-`https://everytime.kr/timetable*` 탭을 우선 사용합니다. 탭이 없으면 비활성
-임시 탭을 열고, 로그인이 필요한 경우에만 해당 탭을 활성화합니다. 로그인 후에는
-content script가 `#semesters`에서 학기 목록을 읽고, 현재 학사 시기를 기준으로
-에브리타임의 학기별 XML API를 동시 네 개까지 요청합니다. API를 사용할 수 없을
-때만 비활성 탭에서 해당 학기를 실제 렌더링한 뒤 DOM을 읽습니다. 1학기(1~6월)에는 해당 연도의
-1학기를, 여름방학(7~8월)과 2학기(9~12월)에는 해당 연도의 2학기를 첫 항목으로
-잡습니다. 첫 네 학기가 모두 비어 있으면 그보다 이전 네 학기를 이어서 요청하며,
-수업이 하나라도 발견되거나 에타의 학기 목록 끝에 도달하면 멈춥니다. XML 응답에서는
-학기 시작·종료일과 지원 상태, 시간표 ID·이름·공개/대표 여부·생성/수정일,
-과목 ID·내부 ID·교수·학점·폐강 여부·시간 원문, 각 수업의 요일·시작/종료값·강의실을
-구조화해 `chrome.storage.local`에 저장합니다. 시간이 없는 과목도 `courses`에
-남겨 정보가 유실되지 않도록 합니다. DOM fallback은
-`#container.timetable table.tablebody div.cols > div.subject`에서 화면에 존재하는
-필드만 읽습니다. popup의 `이전 4학기 추가`
-메뉴는 그보다 앞선 네 개 학기를 같은 과정으로 추가합니다.
+```text
+Popup
+  → Background import handler
+  → 로그인된 Everytime 탭 재사용 또는 임시 탭 생성
+  → Content script의 학기·시간표 XML API
+  → API 실패 시 렌더링된 DOM fallback
+  → 구조화 snapshot 저장
+```
 
-시간표 갱신은 popup에서 사용자가 `동기화`를 누른 경우에만 실행됩니다. 새 학기는
-기존 collection에 추가하고, 같은 에브리타임 학기는 최신 snapshot으로 갱신하되
-다른 학기와 직접 업로드한 이미지는 삭제하지 않습니다. 이미 사용자가 보고 있던
-시간표가 있으면 active 선택도 바꾸지 않습니다. 사용자 수정은 course/subject
-override와 숨김·사용자 추가 항목으로 별도 저장되며, 화면에서는 최신 snapshot에
-이를 병합합니다. 시간표 자체를 삭제할 때만 해당 override도 함께 삭제합니다.
-시간표 화면은 기본 월~금 열을 popup 전체 폭으로 표시하고, 실제 토요일·일요일
-수업이 있을 때만 해당 요일 열을 추가합니다. 짧은 시간표도 남은 세로 영역을
-채우며, 긴 시간표는 내부 세로 스크롤로 확인합니다.
-LinKU는 에브리타임 password, cookie, session token을 읽거나 저장하지 않습니다.
+가져오기는 사용자가 요청할 때만 실행됩니다. 현재 학사 시기의 네 학기부터
+탐색하고, 묶음 전체가 비어 있으면 이전 묶음으로 이동합니다. 수동 동기화는 새
+학기를 추가하고 같은 학기의 snapshot만 갱신하며, 다른 학기·업로드 이미지·active
+선택은 유지합니다.
 
-## UI 시스템
+원본 snapshot과 사용자 override는 별도 저장하고 조회 시 병합합니다. 현재
+popup에는 override 편집 UI가 없지만 저장 경계는 원본을 덮지 않도록 분리되어
+있습니다. LinKU는 Everytime password, cookie, session token을 읽거나 저장하지
+않습니다.
 
-UI는 다음을 사용합니다.
+### 공개 공지
 
-- Styling에는 Tailwind CSS를 사용합니다.
-- `src/components/ui/` 아래에는 shadcn-style Radix wrapper가 있습니다.
-- Icon에는 `lucide-react`를 사용합니다.
-- Toast notification에는 `sonner`를 사용합니다.
-- Editor drag behavior에는 `@dnd-kit/*`를 사용합니다.
-- Carousel behavior에는 `embla-carousel`을 사용합니다.
+공개 공지는 학교 RSS와 HTML source별로 `chrome.storage.local`에 캐시합니다.
+화면 진입 시 필요한 source만 갱신하고, 실패하면 기존 캐시를 유지합니다.
+popup이 닫힌 동안 background polling은 실행하지 않습니다.
 
-새 component library를 도입하기보다 existing UI primitive와 local pattern을
-우선 사용하세요.
+## Storage
 
-## CI와 배포
+- `chrome.storage.local`: auth, 설정, todo, badge, 공지 캐시, 시간표 metadata와
+  snapshot/override.
+- `localStorage`: template draft와 local template.
+- IndexedDB: 사용자가 직접 올린 시간표 이미지 blob.
 
-GitHub Actions workflow는 `.github/workflows/`에 있습니다.
+시간표 metadata의 read-modify-write는 Web Locks로 popup과 background 사이에서
+직렬화합니다. 저장 shape를 변경할 때는 기존 schema migration과 사용자 데이터
+보존을 함께 구현해야 합니다.
 
-- `pr-build-check.yml`: PR에서 local production-like build check를 실행합니다.
-- `upload-chrome-extension-draft.yml`: main에서 Chrome Web Store draft를
-  upload합니다.
-- `create-release.yml`: GitHub Release를 만들고 built zip을 첨부합니다.
-- `deploy-gh-pages.yml`: static assets/pages를 `gh-pages`에 deploy합니다.
+## UI 구성
 
-main branch는 release-sensitive합니다. versioning과 deployment behavior는
-의도적으로 변경하고 PR에 문서화해야 합니다.
+UI는 Tailwind CSS, shadcn-style Radix primitive, Lucide icon을 사용합니다.
+공통 primitive를 우선 재사용합니다. 하나의 feature가 loading·empty·saved·dialog
+같은 여러 역할로 구성되면 compound component로 조합하되, 단일 역할 component를
+불필요하게 감싸지 않습니다.
 
-## 알려진 기술 부채
+## 권한과 배포
 
-- lint는 설정되어 있지만 현재 PR CI에서 강제하지 않습니다.
-- test framework 또는 automated browser extension test suite가 없습니다.
-- `README.md`는 product-focused 문서이며, 깊은 협업 문서는 `docs/` 아래에
-  있습니다.
-- 일부 production code에 diagnostic logging이 남아 있습니다.
-- `public/manifest.json`에는 broad host permissions가 포함되어 있습니다.
-- template persistence는 `localStorage`를 사용하고, 다른 extension state는
-  `chrome.storage.local`을 사용합니다.
+Chrome permission과 `host_permissions`는 `public/manifest.json`에서 관리합니다.
+새 권한은 필요한 domain과 API로 최소화하고, 변경 시 보안 경계와 실제 extension
+검증 방법을 PR에 기록합니다.
 
-이 항목들은 별도 cleanup PR로 다루기 좋습니다. unrelated feature work에 섞지
-마세요.
+PR은 `.github/workflows/pr-build-check.yml`에서 build를 검증합니다. main의 release
+workflow가 manifest version, Chrome Web Store draft, GitHub Release와 Pages 배포를
+관리하므로 일반 PR에서 `public/manifest.json` version을 직접 수정하지 않습니다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,9 +206,9 @@ feature-specific API module은 fetch behavior를 중복 구현하지 말고 이 
   todo, library token, badge count, timetable metadata.
 - `localStorage`: `src/utils/templateStorage.ts`를 통한 template draft와 local
   template persistence.
-- IndexedDB: 사용자가 직접 업로드한 timetable PNG blob만 저장합니다. 이미지와
-  metadata index를 분리해 향후 backend sync를 붙일 수 있도록 metadata에 schema
-  version과 sync status를 둡니다.
+- IndexedDB: 사용자가 직접 업로드한 PNG, JPG/JPEG, WebP, GIF, AVIF timetable
+  이미지 blob만 저장합니다. 이미지와 metadata index를 분리해 향후 backend
+  sync를 붙일 수 있도록 metadata에 schema version과 sync status를 둡니다.
 - `chrome.storage.local`: 에브리타임 원본 snapshot은 `timetableAssetIndex`의
   schema v3 asset에, 사용자 수정은 별도 `timetableEverytimeOverrides`의 schema
   v1 index에 저장합니다. 조회할 때만 `src/utils/everytimeTimetable.ts`가 두 층을
@@ -306,7 +306,7 @@ content script가 `#semesters`에서 학기 목록을 읽고, 현재 학사 시�
 
 시간표 갱신은 popup에서 사용자가 `동기화`를 누른 경우에만 실행됩니다. 새 학기는
 기존 collection에 추가하고, 같은 에브리타임 학기는 최신 snapshot으로 갱신하되
-다른 학기와 직접 업로드한 PNG는 삭제하지 않습니다. 이미 사용자가 보고 있던
+다른 학기와 직접 업로드한 이미지는 삭제하지 않습니다. 이미 사용자가 보고 있던
 시간표가 있으면 active 선택도 바꾸지 않습니다. 사용자 수정은 course/subject
 override와 숨김·사용자 추가 항목으로 별도 저장되며, 화면에서는 최신 snapshot에
 이를 병합합니다. 시간표 자체를 삭제할 때만 해당 override도 함께 삭제합니다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,14 +6,18 @@
 ## 시스템 개요
 
 LinKU는 Vite, React, TypeScript, Tailwind CSS로 만든 Manifest V3 Chrome
-Extension입니다. 확장 프로그램은 두 개의 런타임 영역을 가집니다.
+Extension입니다. 확장 프로그램은 세 개의 런타임 영역을 가집니다.
 
 - `index.html`에서 렌더링되는 Popup UI.
 - `src/background/index.ts`에서 빌드되는 Background service worker.
+- `src/content/everytime-timetable.ts`에서 빌드되어 에브리타임 시간표
+  페이지에서만 실행되는 content script.
 
-현재 프로젝트에는 content script가 없습니다. 확장 프로그램은 임의의 web page에
-UI나 logic을 주입하지 않습니다. 대부분의 user interaction은 popup 내부에서
-일어납니다.
+대부분의 user interaction은 popup 내부에서 일어납니다. content script는
+로그인된 에브리타임 탭에서 시간표 XML API를 호출하고, API를 사용할 수 없을 때만
+렌더링된 시간표 DOM을 구조화해 읽습니다. 브라우저가 요청에 기존 로그인 쿠키를
+자동으로 포함하지만 LinKU는 password, cookie, session token을 직접 읽거나
+저장하지 않습니다.
 
 ## Backend 의존성
 
@@ -36,6 +40,8 @@ template, icons, alerts 같은 backend 연동 기능은 `VITE_API_BASE_URL`이
 
 - `index.html`은 popup entry가 됩니다.
 - `src/background/index.ts`는 `background/index.js`가 됩니다.
+- `src/content/everytime-timetable.ts`는
+  `content/everytime-timetable.js`가 됩니다.
 
 `gh-pages` mode에서는 build output이 `gh-pages/`로 바뀌고, static hosting을
 위해 banner asset이 복사됩니다. extension build의 output directory는
@@ -74,6 +80,19 @@ public/manifest.json
   -> background.service_worker: background/index.js
   -> src/background/index.ts
   -> src/background/handlers/oauth.ts
+  -> src/background/handlers/timetable.ts
+```
+
+Everytime import 흐름:
+
+```text
+public/manifest.json
+  -> content_scripts.matches: https://everytime.kr/timetable*
+  -> src/content/everytime-timetable.ts
+  -> Everytime semester/table XML API (rendered DOM fallback)
+  -> chrome.runtime message
+  -> src/background/handlers/timetable.ts
+  -> chrome.storage.local structured timetable collection
 ```
 
 popup은 React Router의 hash routing을 사용합니다. Chrome extension popup
@@ -103,6 +122,7 @@ src/
   assets/        local image와 SVG asset
   background/    Manifest V3 service worker code
   components/    feature component와 UI primitive
+  content/       제한된 외부 페이지 content script
   constants/     정적 app data
   contexts/      React Context 상태 container
   hooks/         reusable React hook
@@ -120,6 +140,7 @@ src/
 - Banners: `src/components/Tabs/ImageCarousel.tsx`
 - Todo list: `src/components/Tabs/TodoList/`
 - Alerts: `src/components/Tabs/Alerts/`
+- Timetable: `src/components/Tabs/TimeTable/`
 - Labs: `src/components/Labs/`
 
 Template system 구성:
@@ -136,6 +157,7 @@ Auth 및 account 관련 UI:
 
 - OAuth popup/background bridge: `src/utils/oauth.ts`
 - Background OAuth handler: `src/background/handlers/oauth.ts`
+- Background timetable handler: `src/background/handlers/timetable.ts`
 - API auth interceptor: `src/apis/client.ts`
 - Email verification dialog: `src/components/EmailVerificationDialog.tsx`
 - Settings dialog: `src/components/SettingsDialog.tsx`
@@ -151,6 +173,7 @@ background worker가 처리하는 일:
 
 - Google login request.
 - Silent reauth request.
+- User-triggered Everytime timetable import request.
 - Extension install/update event.
 - Badge count initialization.
 - `chrome.storage.local` 변경에 따른 badge count update.
@@ -177,12 +200,20 @@ feature-specific API module은 fetch behavior를 중복 구현하지 말고 이 
 
 ## Storage 모델
 
-현재 storage는 두 browser storage system으로 나뉘어 있습니다.
+현재 storage는 세 browser storage system으로 나뉘어 있습니다.
 
 - `chrome.storage.local`: auth token, user profile state, settings, custom
-  todo, library token, badge count.
+  todo, library token, badge count, timetable metadata.
 - `localStorage`: `src/utils/templateStorage.ts`를 통한 template draft와 local
   template persistence.
+- IndexedDB: 사용자가 직접 업로드한 timetable PNG blob만 저장합니다. 이미지와
+  metadata index를 분리해 향후 backend sync를 붙일 수 있도록 metadata에 schema
+  version과 sync status를 둡니다.
+- `chrome.storage.local`: 에브리타임 원본 snapshot은 `timetableAssetIndex`의
+  schema v3 asset에, 사용자 수정은 별도 `timetableEverytimeOverrides`의 schema
+  v1 index에 저장합니다. 조회할 때만 `src/utils/everytimeTimetable.ts`가 두 층을
+  병합합니다. 동기화는 snapshot만 갱신하므로 사용자 수정 저장소를 덮지 않습니다.
+  원본 HTML, password, cookie, session token은 저장하지 않습니다.
 
 이 분리는 과거 설계의 결과입니다. template local persistence flow를 직접
 수정하는 경우가 아니라면, 새 extension-wide state는 `chrome.storage.local`을
@@ -190,7 +221,8 @@ feature-specific API module은 fetch behavior를 중복 구현하지 말고 이 
 
 stored data shape를 바꿀 때는 기존 user의 migration behavior를 고려해야
 합니다. LinKU는 실제 user에게 배포되는 extension이므로 가능한 한 backward
-compatible해야 합니다.
+compatible해야 합니다. 시간표 asset schema v2는 처음 읽을 때 v3 snapshot
+구조로 자동 변환합니다.
 
 ## 인증
 
@@ -252,6 +284,36 @@ flowchart LR
 경계만 교체할 수 있습니다. 단, frontend-only 구조에서는 학교가
 게시물을 source에서 제거하거나 local storage가 삭제된 기간까지 절대적인 무누락을
 보장할 수 없으며, 현재 공개된 목록 안에서 확인 가능한 동기화 경계만 보존합니다.
+
+### Everytime 시간표
+
+사용자가 popup에서 가져오기를 누르면 background worker는 이미 열린
+`https://everytime.kr/timetable*` 탭을 우선 사용합니다. 탭이 없으면 비활성
+임시 탭을 열고, 로그인이 필요한 경우에만 해당 탭을 활성화합니다. 로그인 후에는
+content script가 `#semesters`에서 학기 목록을 읽고, 현재 학사 시기를 기준으로
+에브리타임의 학기별 XML API를 동시 네 개까지 요청합니다. API를 사용할 수 없을
+때만 비활성 탭에서 해당 학기를 실제 렌더링한 뒤 DOM을 읽습니다. 1학기(1~6월)에는 해당 연도의
+1학기를, 여름방학(7~8월)과 2학기(9~12월)에는 해당 연도의 2학기를 첫 항목으로
+잡습니다. 첫 네 학기가 모두 비어 있으면 그보다 이전 네 학기를 이어서 요청하며,
+수업이 하나라도 발견되거나 에타의 학기 목록 끝에 도달하면 멈춥니다. XML 응답에서는
+학기 시작·종료일과 지원 상태, 시간표 ID·이름·공개/대표 여부·생성/수정일,
+과목 ID·내부 ID·교수·학점·폐강 여부·시간 원문, 각 수업의 요일·시작/종료값·강의실을
+구조화해 `chrome.storage.local`에 저장합니다. 시간이 없는 과목도 `courses`에
+남겨 정보가 유실되지 않도록 합니다. DOM fallback은
+`#container.timetable table.tablebody div.cols > div.subject`에서 화면에 존재하는
+필드만 읽습니다. popup의 `이전 4학기 추가`
+메뉴는 그보다 앞선 네 개 학기를 같은 과정으로 추가합니다.
+
+시간표 갱신은 popup에서 사용자가 `동기화`를 누른 경우에만 실행됩니다. 새 학기는
+기존 collection에 추가하고, 같은 에브리타임 학기는 최신 snapshot으로 갱신하되
+다른 학기와 직접 업로드한 PNG는 삭제하지 않습니다. 이미 사용자가 보고 있던
+시간표가 있으면 active 선택도 바꾸지 않습니다. 사용자 수정은 course/subject
+override와 숨김·사용자 추가 항목으로 별도 저장되며, 화면에서는 최신 snapshot에
+이를 병합합니다. 시간표 자체를 삭제할 때만 해당 override도 함께 삭제합니다.
+시간표 화면은 기본 월~금 열을 popup 전체 폭으로 표시하고, 실제 토요일·일요일
+수업이 있을 때만 해당 요일 열을 추가합니다. 짧은 시간표도 남은 세로 영역을
+채우며, 긴 시간표는 내부 세로 스크롤로 확인합니다.
+LinKU는 에브리타임 password, cookie, session token을 읽거나 저장하지 않습니다.
 
 ## UI 시스템
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,301 +1,102 @@
 # 기여 가이드
 
-이 문서는 LinKU의 확장 프로그램 release flow를 깨뜨리지 않고, 이후 유지보수가
-가능한 방식으로 협업하기 위한 기준을 설명합니다.
+LinKU는 실제 사용자가 설치하는 Chrome Extension입니다. 변경 범위를 작게 유지하고
+사용자 데이터, permission, 인증, release 흐름에 미치는 영향을 명확히 드러내세요.
 
-## 시작하기 전에
-
-LinKU는 Chrome Web Store를 통해 배포되는 실제 Chrome Extension입니다.
-변경사항은 review 가능한 크기로 유지하고, 사용자 영향, permission,
-authentication, release automation에 미치는 영향을 명확히 드러내야 합니다.
-
-feature proposal, behavior change, permission change, 큰 refactor는 먼저
-GitHub Issues에서 논의하세요. 의도가 분명한 작은 bug fix와 documentation
-improvement는 바로 PR로 진행해도 됩니다.
-
-## 프로젝트 빠른 이해
-
-LinKU는 건국대학교 학생을 위한 Manifest V3 Chrome Extension입니다. 교내 공식
-사이트, 학생 제작 서비스, 공지, todo, template, Labs 기능을 하나의 popup에서
-사용할 수 있게 합니다.
-
-현재 content script는 `https://everytime.kr/timetable*`에서 시간표 XML 응답을
-구조화하고, API 실패 시 렌더링된 시간표 DOM을 파싱하는 제한된 용도로만 사용합니다. 다른 방문 페이지에 script를 추가할
-때는 match pattern과 수집 데이터 범위를 명시해야 합니다. popup과 Background
-service worker 사이의 통신은 `chrome.runtime.sendMessage`와
-`src/background/types.ts`의 type guard를 통해 이루어집니다.
-
-에브리타임 시간표 변경은 실제 로그인된 탭에서 수동 검증이 필요합니다. 가져오기
-후에는 현재 학사 시기의 최근 네 개 학기부터 요청되는지(여름방학에는 해당 연도
-2학기부터), 그 묶음이 비어 있으면 이전 네 학기로 계속 탐색하는지, 빈 학기가 저장되지 않는지,
-수업이 있는 학기만 popup의 선택 목록에 나타나는지, `이전 4학기 추가`가 그보다
-앞선 네 개 학기를 추가하는지 확인하세요. 수동 동기화 뒤에도 기존 학기, 직접
-업로드한 이미지, active 선택이 유지되어야 합니다. password, cookie, session token은
-어떤 검증 로그에도 남기지 않습니다. 저장된 구조 데이터에는 학기·시간표·과목·수업시간
-메타데이터가 포함되고, 시간이 없는 과목도 `courses`에 남는지 함께 확인합니다.
-사용자 override가 있는 학기를 다시 동기화할 때 `snapshot` checksum과 수정 시각은
-바뀔 수 있지만 `timetableEverytimeOverrides` 값과 병합된 화면은 유지되어야 합니다.
-기존 schema v2 시간표는 첫 조회에서 schema v3 `snapshot` 구조로 마이그레이션되어야
-합니다.
-
-직접 업로드하는 시간표 이미지는 PNG, JPG/JPEG, WebP, GIF, AVIF를 지원합니다.
-확장자나 브라우저가 전달한 MIME type만 믿지 않고 파일 signature와 실제 이미지
-decode를 모두 통과하는지 확인하며, 기존 8MB 및 280×180 최소 크기 제한을 유지합니다.
-
-기술 스택은 다음을 기준으로 이해하면 됩니다.
-
-- Build: Vite 8, `@vitejs/plugin-react-swc`
-- UI: React 19, TypeScript 6, Tailwind CSS 4, shadcn/ui, Radix UI
-- Routing: `react-router-dom` v7, hash routing
-- State: 별도 전역 상태 라이브러리 없이 React Context 사용
-- Extension runtime: Manifest V3, Background service worker
-- Package manager/runtime: pnpm, Node.js 24 LTS
-- Supporting libraries: `@dnd-kit/*`, `embla-carousel`, `cmdk`, `sonner`,
-  `lucide-react`, `react-error-boundary`
-
-## 코드베이스 빠른 지도
-
-주요 디렉터리 역할은 다음과 같습니다.
-
-- `src/background/`: MV3 Background service worker, OAuth, badge update.
-- `src/pages/`: route 단위 page. Main, Editor, TemplateList, Gallery,
-  NotFound가 여기에 있습니다.
-- `src/components/Tabs/`: main popup tab 기능. link group, todo, alerts,
-  carousel 등이 여기에 모입니다.
-- `src/components/Editor/`: template editor UI, canvas, sidebar, header.
-- `src/components/Labs/`: 실험 기능. library seat, QR generator, server clock.
-- `src/components/ui/`: shadcn/ui 스타일의 Radix UI wrapper.
-- `src/contexts/`: React Context 기반 상태 관리. `EditorContext.tsx`가
-  template editor 상태의 중심입니다.
-- `src/apis/`: LinKU backend API wrapper와 endpoint 정의.
-- `src/apis/external/`: eCampus, library, RSS, HTML parsing, banners 같은
-  외부 또는 학교 사이트 연동.
-- `src/utils/`: analytics, chrome, crypto, oauth, template, templateStorage
-  등 cross-cutting utility.
-- `src/constants/`: `LinkList.ts` 같은 정적 app data.
-- `src/types/`: backend response와 domain model의 TypeScript contract.
-
-더 자세한 runtime 구조와 데이터 흐름은 `docs/ARCHITECTURE.md`를 기준으로
-확인하세요.
-
-## 로컬 설정
+## 시작하기
 
 ```bash
 pnpm install
 pnpm run dev
 ```
 
-`pnpm run dev`는 React UI를 빠르게 확인할 때 사용합니다. 이 환경은 Chrome
-확장 프로그램 runtime을 완전히 재현하지 않습니다.
-
-확장 프로그램 검증에는 다음 명령을 사용합니다.
+`pnpm run dev`는 React UI 확인용입니다. Chrome extension runtime 검증에는 다음
+명령으로 만든 `dist/`를 `chrome://extensions`에서 로드합니다.
 
 ```bash
 pnpm run build:local
 ```
 
-이후 `chrome://extensions`를 열고 Developer Mode를 활성화한 뒤, 생성된
-`dist/` 디렉터리를 unpacked extension으로 로드하세요.
+backend 기능에는 유효한 `VITE_API_BASE_URL`이 필요합니다. 실제 secret은 commit하지
+마세요.
 
-## 환경 변수
+## 작업 원칙
 
-`.env.development.example`을 복사해 `.env.development`를 만듭니다.
+- 하나의 branch와 PR은 하나의 목적에 집중합니다.
+- 기존 working tree의 사용자 변경과 저장된 데이터의 하위 호환성을 보존합니다.
+- route, feature, external API, background 책임은 `docs/ARCHITECTURE.md`의 소스
+  경계를 따릅니다.
+- 외부 API·DOM parser는 수집 범위와 fallback을 명확히 하고 실패를 사용자 데이터
+  손실로 이어지게 하지 않습니다.
+- feature PR에서 새로운 state library, router, styling system, formatter, test
+  framework를 함께 도입하지 않습니다.
+- loading·empty·saved·dialog처럼 하나의 feature 화면이 여러 역할로 나뉘면
+  compound component를 우선 검토합니다.
 
-중요한 변수:
+커밋은 가능한 한 작은 단위로 나누고 Conventional Commits 형식을 권장합니다.
 
-- `VITE_API_BASE_URL`: LinKU backend API base URL입니다. auth, templates,
-  icons, alerts, public gallery data 같은 backend-backed feature에 필요합니다.
-- `VITE_GA_API_SECRET`: Google Analytics Measurement Protocol secret입니다.
-  analytics 동작을 검증하지 않는 대부분의 local development에서는 필수는
-  아닙니다.
-- `VITE_ENVIRONMENT`: analytics 동작에서 사용하는 environment flag입니다.
+```text
+feat: add user-facing behavior
+fix(auth): handle expired token
+refactor(editor): split canvas helpers
+docs: update contributor guide
+```
 
-`VITE_API_BASE_URL`이 없거나 placeholder 값으로 남아 있으면, local build를
-해도 Google OAuth login과 `src/apis/` 기반 backend API 검증은 정상적으로
-진행되지 않습니다. auth, templates, icons, alerts 같은 기능을 확인하려면
-실제 backend URL이 필요합니다.
+## 검증
 
-실제 secret을 commit하지 마세요. `.env.*` 파일은 example file을 제외하고
-ignore됩니다.
+모든 code change는 최소한 다음을 통과해야 합니다.
 
-## 브랜치 전략
+```bash
+pnpm run build:local
+```
 
-이 저장소는 `main`을 통합 branch로 사용합니다.
+TypeScript, React hook, shared utility를 수정했다면 lint를 실행합니다. 시간표 도메인
+로직을 수정했다면 전용 회귀 테스트도 실행합니다.
 
-권장 branch prefix:
+```bash
+pnpm run lint
+pnpm run test:timetable
+```
 
-- `feat/*`: 사용자에게 보이는 feature.
-- `fix/*`: bug fix.
-- `refactor/*`: 동작을 유지하는 code change.
-- `docs/*`: documentation.
-- `config/*` 또는 `ci/*`: tooling과 workflow change.
+변경 유형별 추가 확인:
 
-branch는 하나의 목적에 집중하세요. feature work, formatting churn, 관련 없는
-cleanup을 한 PR에 섞지 않는 것이 좋습니다.
+- UI: 실제 popup 크기에서 layout, keyboard, loading/error 상태.
+- Background, storage, OAuth, badge: 빌드된 unpacked extension.
+- 외부 사이트 parser: 실제 페이지·응답과 fallback. 로그인 정보나 원문 응답을
+  로그 또는 fixture에 남기지 않습니다.
+- Permission: 추가된 API/domain이 최소 범위인지 확인합니다.
 
-## 커밋 스타일
-
-가능하면 Conventional Commits를 사용합니다.
-
-- `feat: add template gallery filter`
-- `fix(auth): handle expired token response`
-- `refactor(editor): split canvas helpers`
-- `docs: add architecture guide`
-- `ci: add lint check`
-
-현재 commitlint 또는 Husky enforcement는 없습니다. 따라서 commit style은
-local gate가 아니라 review convention입니다.
+테스트하지 못한 범위와 기존 실패는 PR 설명에 명시합니다.
 
 ## PR 체크리스트
 
-review 요청 전 다음 내용을 포함하세요.
+- 변경 목적과 사용자 영향 요약.
+- 실행한 검증 명령과 수동 확인 결과.
+- UI 변경의 screenshot 또는 GIF.
+- backend·외부 응답 shape 가정.
+- permission 변경 사유와 실제 extension 검증 방법.
+- migration 또는 사용자 데이터 보존 영향.
 
-- behavior 또는 documentation change 요약.
-- visible UI change가 있다면 screenshot 또는 GIF.
-- extension-only behavior에 대한 manual test notes.
-- backend API assumption 또는 response-shape change.
-- permission change가 있다면 각 permission이 필요한 이유.
-- verification command의 실행 결과 또는 상태.
+## 보안과 로깅
 
-권장 local check:
+- `host_permissions`는 domain 단위로 최소화하고 `<all_urls>`를 새로 사용하지
+  않습니다.
+- access/refresh token, auth code, secret, authorization header, cookie, private
+  user data를 로그에 남기지 않습니다.
+- `console.*` 대신 `src/utils/logger.ts`를 사용하고 production에는 필요한
+  warn/error만 남깁니다.
+- 외부 응답 전체보다 상태 코드와 비민감 핵심 필드만 기록합니다.
 
-```bash
-pnpm run build:local
-pnpm run lint
-```
+## 릴리즈와 문서
 
-현재 CI는 PR에서 `pnpm run build:local`을 실행합니다. shared code, React hooks,
-TypeScript utility를 변경했다면 가능한 한 local에서 lint도 실행하세요.
+일반 PR에서 `public/manifest.json` version을 직접 수정하지 않습니다. main의
+workflow가 Chrome Web Store draft, GitHub Release, Pages 배포와 version bump를
+담당합니다.
 
-현재 프로젝트에는 Prettier, Stylelint, Husky, lint-staged, test framework,
-pre-commit hook이 없습니다. formatting과 test coverage는 자동으로 보장되지
-않으므로, 변경 범위에 맞는 manual verification을 PR 설명에 남기는 것이
-중요합니다.
+- `README.md`: 제품 소개와 빠른 시작.
+- `docs/ARCHITECTURE.md`: 런타임 경계와 데이터 흐름.
+- `docs/CONTRIBUTING.md`: 작업·검증·PR 규칙.
+- `AGENTS.md`: 코딩 에이전트 진입점.
 
-## 수동 테스트 가이드
-
-layout과 interaction을 빠르게 확인할 때는 `pnpm run dev`를 사용하고, runtime
-behavior는 빌드된 extension으로 검증합니다.
-
-다음 영역을 수정했다면 unpacked extension으로 검증하세요.
-
-- `src/background/`
-- `src/utils/chrome.ts`
-- `src/utils/oauth.ts`
-- `src/apis/client.ts`
-- `public/manifest.json`
-- storage behavior
-- OAuth behavior
-- badge updates
-- host permissions
-- external school-site integrations
-
-UI change는 popup viewport size와 영향을 받는 route를 확인하세요. template
-editor change는 관련 범위에 따라 create, edit, save locally, sync, drag,
-resize, template list로 돌아가는 navigation을 확인하세요.
-
-## 아키텍처 경계
-
-현재 source boundary를 따르세요.
-
-- Route-level screen은 `src/pages/`에 둡니다.
-- Layout wrapper는 `src/layouts/`에 둡니다.
-- Reusable UI primitive는 `src/components/ui/`에 둡니다.
-- Main popup feature section은 `src/components/Tabs/`에 둡니다.
-- Template editor component는 `src/components/Editor/`에 둡니다.
-- Backend API wrapper는 `src/apis/`에 둡니다.
-- External school 또는 third-party integration은 `src/apis/external/`에 둡니다.
-- Shared type contract는 `src/types/`에 둡니다.
-- Cross-cutting browser와 data utility는 `src/utils/`에 둡니다.
-- MV3 background code는 `src/background/`에 둡니다.
-
-feature PR 안에서 새로운 state library, router, styling system, formatter,
-test framework를 도입하지 마세요. 그런 변경은 별도 tooling decision PR로
-다루는 것이 좋습니다.
-
-## Chrome 권한 정책
-
-permission change는 추가 검토가 필요합니다.
-
-`public/manifest.json`을 수정할 때는 다음을 설명하세요.
-
-- 어떤 feature가 해당 permission을 필요로 하는지.
-- 어떤 API 또는 domain이 해당 permission을 요구하는지.
-- 더 좁은 permission으로 충분하지 않은 이유.
-- Chrome에서 해당 behavior를 어떻게 manual test했는지.
-
-넓은 access보다 domain-specific `host_permissions`를 선호하세요. `<all_urls>`는
-legacy 또는 temporary permission으로 보고, 가볍게 확장하지 마세요.
-
-## 로깅 규칙
-
-runtime log는 필요한 최소한만 남기고, 정책은 `src/utils/logger.ts`를 기준으로
-일관되게 적용합니다.
-
-- `console.log`, `console.warn`, `console.error`, `console.info`를 직접 호출하지
-  말고 공통 logger를 사용하세요.
-- `debug`/`info` 수준 로그는 개발 환경에서만 출력되도록 유지하세요.
-- 운영 환경에는 장애 원인 파악에 필요한 `warn`/`error`만 남기고, 동일한 실패를
-  여러 계층에서 중복 기록하지 마세요.
-- access token, refresh token, auth code, secret, authorization header,
-  private user data 같은 민감정보를 로그에 남기지 마세요.
-- 외부 응답 본문이나 큰 object 전체 dump 대신, 상태 코드와 비민감 핵심 필드만
-  선택적으로 기록하세요.
-
-## 외부 사이트 연동
-
-`src/apis/external/` 아래 파일은 external markup 또는 API에 의존합니다. 이
-영역을 변경할 때는 무엇을 검증했는지 문서화하세요.
-
-- Target URL 또는 service.
-- Verification date.
-- Example response 또는 DOM assumption.
-- Parsing 실패 시 fallback behavior.
-
-이 integration들은 학교 또는 외부 사이트가 구조를 바꾸면 코드 변경 없이도
-깨질 수 있습니다.
-
-## 첫 기여 흐름
-
-처음 기여한다면 다음 순서로 진행하세요.
-
-1. GitHub Issue에서 변경 의도와 범위를 확인하거나 제안합니다.
-2. `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `config/*`, `ci/*` 중 적절한
-   branch prefix로 작업 branch를 만듭니다.
-3. 관련 source와 `docs/ARCHITECTURE.md`를 읽고 변경 위치를 좁힙니다.
-4. 코드를 수정하고 `pnpm run build:local`을 실행합니다.
-5. 가능하면 `pnpm run lint`도 실행합니다.
-6. `dist/`를 Chrome에 로드해 실제 extension 동작을 확인합니다.
-7. PR에 변경 요약, 검증 결과, UI 변경 screenshot/GIF, permission 변경 사유를
-   남깁니다.
-
-실제 사용자가 있는 확장 프로그램이므로 “브라우저에서 직접 확인했다”는 기록은
-review에서 중요합니다.
-
-## 릴리즈와 버전 관리
-
-일반 PR에서 `public/manifest.json`의 version을 직접 bump하지 마세요.
-
-main-branch workflow가 다음을 처리합니다.
-
-- Chrome Web Store draft upload.
-- GitHub Release creation.
-- GitHub Pages deployment.
-- `scripts/updateVersion.js`를 통한 manifest patch version bump.
-
-release workflow가 `chore: bump version ... [skip ci]` commit을 생성했다면,
-release process 자체를 고치는 경우가 아니라면 amend하거나 rebase로 제거하지
-마세요.
-
-## 문서화 규칙
-
-`README.md`는 product overview와 quick start 중심으로 유지합니다.
-
-용도별 문서:
-
-- `docs/ARCHITECTURE.md`: runtime design과 technical map.
-- `docs/CONTRIBUTING.md`: collaboration rule.
-- `AGENTS.md`: AI coding-agent orientation.
-
-architecture, workflow, permission, environment variable, onboarding step을
-변경했다면 같은 PR에서 documentation도 갱신하세요.
+architecture, permission, workflow 또는 onboarding이 바뀌면 관련 문서만 같은 PR에서
+갱신합니다.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,11 +19,24 @@ LinKU는 건국대학교 학생을 위한 Manifest V3 Chrome Extension입니다.
 사이트, 학생 제작 서비스, 공지, todo, template, Labs 기능을 하나의 popup에서
 사용할 수 있게 합니다.
 
-현재 구조에는 content script가 없습니다. `public/manifest.json`은 popup UI와
-Background service worker를 선언하며, 방문 중인 페이지에 script를 주입하지
-않습니다. popup과 Background service worker 사이의 통신은
-`chrome.runtime.sendMessage`와 `src/background/types.ts`의 type guard를 통해
-이루어집니다.
+현재 content script는 `https://everytime.kr/timetable*`에서 시간표 XML 응답을
+구조화하고, API 실패 시 렌더링된 시간표 DOM을 파싱하는 제한된 용도로만 사용합니다. 다른 방문 페이지에 script를 추가할
+때는 match pattern과 수집 데이터 범위를 명시해야 합니다. popup과 Background
+service worker 사이의 통신은 `chrome.runtime.sendMessage`와
+`src/background/types.ts`의 type guard를 통해 이루어집니다.
+
+에브리타임 시간표 변경은 실제 로그인된 탭에서 수동 검증이 필요합니다. 가져오기
+후에는 현재 학사 시기의 최근 네 개 학기부터 요청되는지(여름방학에는 해당 연도
+2학기부터), 그 묶음이 비어 있으면 이전 네 학기로 계속 탐색하는지, 빈 학기가 저장되지 않는지,
+수업이 있는 학기만 popup의 선택 목록에 나타나는지, `이전 4학기 추가`가 그보다
+앞선 네 개 학기를 추가하는지 확인하세요. 수동 동기화 뒤에도 기존 학기, 직접
+업로드한 PNG, active 선택이 유지되어야 합니다. password, cookie, session token은
+어떤 검증 로그에도 남기지 않습니다. 저장된 구조 데이터에는 학기·시간표·과목·수업시간
+메타데이터가 포함되고, 시간이 없는 과목도 `courses`에 남는지 함께 확인합니다.
+사용자 override가 있는 학기를 다시 동기화할 때 `snapshot` checksum과 수정 시각은
+바뀔 수 있지만 `timetableEverytimeOverrides` 값과 병합된 화면은 유지되어야 합니다.
+기존 schema v2 시간표는 첫 조회에서 schema v3 `snapshot` 구조로 마이그레이션되어야
+합니다.
 
 기술 스택은 다음을 기준으로 이해하면 됩니다.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,13 +30,17 @@ service worker 사이의 통신은 `chrome.runtime.sendMessage`와
 2학기부터), 그 묶음이 비어 있으면 이전 네 학기로 계속 탐색하는지, 빈 학기가 저장되지 않는지,
 수업이 있는 학기만 popup의 선택 목록에 나타나는지, `이전 4학기 추가`가 그보다
 앞선 네 개 학기를 추가하는지 확인하세요. 수동 동기화 뒤에도 기존 학기, 직접
-업로드한 PNG, active 선택이 유지되어야 합니다. password, cookie, session token은
+업로드한 이미지, active 선택이 유지되어야 합니다. password, cookie, session token은
 어떤 검증 로그에도 남기지 않습니다. 저장된 구조 데이터에는 학기·시간표·과목·수업시간
 메타데이터가 포함되고, 시간이 없는 과목도 `courses`에 남는지 함께 확인합니다.
 사용자 override가 있는 학기를 다시 동기화할 때 `snapshot` checksum과 수정 시각은
 바뀔 수 있지만 `timetableEverytimeOverrides` 값과 병합된 화면은 유지되어야 합니다.
 기존 schema v2 시간표는 첫 조회에서 schema v3 `snapshot` 구조로 마이그레이션되어야
 합니다.
+
+직접 업로드하는 시간표 이미지는 PNG, JPG/JPEG, WebP, GIF, AVIF를 지원합니다.
+확장자나 브라우저가 전달한 MIME type만 믿지 않고 파일 signature와 실제 이미지
+decode를 모두 통과하는지 확인하며, 기존 8MB 및 280×180 최소 크기 제한을 유지합니다.
 
 기술 스택은 다음을 기준으로 이해하면 됩니다.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "watch:local": "tsc -b && vite build --watch --mode development",
     "build:gh-pages": "tsc -b && vite build --mode gh-pages",
     "lint": "eslint .",
+    "test:timetable": "node --experimental-strip-types --test tests/timetable/*.test.ts",
     "preview": "vite preview",
     "deploy": "git subtree push --prefix gh-pages origin gh-pages"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,6 +17,17 @@
     "service_worker": "background/index.js",
     "type": "module"
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://everytime.kr/timetable*"
+      ],
+      "js": [
+        "content/everytime-timetable.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
   "permissions": [
     "activeTab",
     "scripting",

--- a/src/assets/everytime_symbol.svg
+++ b/src/assets/everytime_symbol.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Source: official Everytime brand resource from VINU Team. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient
+      id="everytime-accent"
+      x1="512.1"
+      y1="396.5"
+      x2="512.1"
+      y2="544.5"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop offset="0" stop-color="#bc0017" />
+      <stop offset="0.11" stop-color="#c30416" />
+      <stop offset="0.28" stop-color="#d90f16" />
+      <stop offset="0.47" stop-color="#f91f15" />
+    </linearGradient>
+  </defs>
+  <path
+    fill="#292929"
+    d="M770.1 350.5c40.9 0 74-33.1 74-74s-33.1-74-74-74-74 33.1-74 74 33.1 74 74 74Z"
+  />
+  <path
+    fill="#292929"
+    d="M883.5 446.5H749.7c0 132.1-106.4 240.3-237.6 240.3S274.5 578.6 274.5 446.5h-134c0 206.5 166.3 375 371.5 375s371.5-168.5 371.5-375Z"
+  />
+  <path
+    fill="url(#everytime-accent)"
+    d="M559.8 396.5H457.1l27.7 126.4c2.8 12.9 13.8 21.6 27.3 21.6s24.6-8.7 27.3-21.6l27.7-126.4h-7.3Z"
+  />
+  <path
+    fill="#f91f15"
+    d="M551.3 351.7c-10.5-10.5-24.4-16.2-39.3-16.2-30.6 0-55.5 24.9-55.5 55.5s24.9 55.5 55.5 55.5 55.5-24.9 55.5-55.5c0-14.8-5.8-28.8-16.2-39.3Z"
+  />
+</svg>

--- a/src/background/handlers/timetable.ts
+++ b/src/background/handlers/timetable.ts
@@ -15,7 +15,7 @@ import {
 } from "@/utils/timetableStorage";
 import { getErrorLogDetails, warnLog } from "@/utils/logger";
 import {
-  getEverytimeSemesterSortKey,
+  getLatestEverytimeSemesterAnchor,
   parseEverytimeSemester,
   type EverytimeSemesterPeriod,
 } from "@/utils/everytimeSemester";
@@ -101,21 +101,6 @@ function isEverytimeTimetableUrl(url?: string): boolean {
   }
 }
 
-function getLatestSemesterAnchor(
-  now: Date,
-): Pick<EverytimeSemesterPeriod, "year" | "term" | "sortKey"> {
-  const month = now.getMonth();
-  const term = month < 6 ? "1" : "2";
-
-  return {
-    year: now.getFullYear(),
-    term,
-    // 1학기(1~6월)에는 1학기를, 여름방학(7~8월)에는 다음 정규학기인 2학기를
-    // 첫 항목으로 둔다. 겨울방학(1~2월)은 새해 1학기부터 시작한다.
-    sortKey: getEverytimeSemesterSortKey(now.getFullYear(), term),
-  };
-}
-
 async function getPendingImport(): Promise<PendingEverytimeImport | null> {
   const stored = await chrome.storage.session.get(
     TIMETABLE_STORAGE_KEYS.pendingImport,
@@ -141,15 +126,34 @@ async function clearPendingImport(): Promise<void> {
 }
 
 async function waitForTabToSettle(tabId: number): Promise<chrome.tabs.Tab> {
-  const currentTab = await chrome.tabs.get(tabId);
-  if (currentTab.status === "complete") {
-    return currentTab;
-  }
-
   return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
+    let settled = false;
+
+    const cleanup = (): void => {
+      clearTimeout(timeoutId);
       chrome.tabs.onUpdated.removeListener(handleUpdated);
-      reject(new Error("에브리타임 페이지를 불러오는 데 시간이 걸리고 있습니다."));
+    };
+    const resolveOnce = (tab: chrome.tabs.Tab): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(tab);
+    };
+    const rejectOnce = (error: unknown): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const timeoutId = setTimeout(() => {
+      rejectOnce(
+        new Error("에브리타임 페이지를 불러오는 데 시간이 걸리고 있습니다."),
+      );
     }, TAB_LOAD_TIMEOUT_MS);
 
     function handleUpdated(
@@ -161,12 +165,18 @@ async function waitForTabToSettle(tabId: number): Promise<chrome.tabs.Tab> {
         return;
       }
 
-      clearTimeout(timeoutId);
-      chrome.tabs.onUpdated.removeListener(handleUpdated);
-      resolve(updatedTab);
+      resolveOnce(updatedTab);
     }
 
     chrome.tabs.onUpdated.addListener(handleUpdated);
+    chrome.tabs
+      .get(tabId)
+      .then((currentTab) => {
+        if (currentTab.status === "complete") {
+          resolveOnce(currentTab);
+        }
+      })
+      .catch(rejectOnce);
   });
 }
 
@@ -174,9 +184,9 @@ async function ensureContentScript(tabId: number): Promise<void> {
   try {
     const response = (await chrome.tabs.sendMessage(tabId, {
       type: "LINKU_EVERYTIME_CAPTURE_PING",
-    })) as EverytimeResponse;
+    })) as EverytimeResponse | undefined;
 
-    if (response.success) {
+    if (response?.success) {
       return;
     }
   } catch {
@@ -202,28 +212,35 @@ async function closeOwnedTab(tabId: number): Promise<void> {
 }
 
 function isSemesterListResponse(
-  response: EverytimeResponse,
+  response: EverytimeResponse | undefined,
 ): response is SemesterListResponse {
-  return response.success && "semesters" in response;
+  return response?.success === true && "semesters" in response;
 }
 
 function isCurrentTimetableResponse(
-  response: EverytimeResponse,
+  response: EverytimeResponse | undefined,
 ): response is CurrentTimetableResponse {
-  return response.success && "timetable" in response;
+  return response?.success === true && "timetable" in response;
 }
 
 function isSemesterFetchResponse(
-  response: EverytimeResponse,
+  response: EverytimeResponse | undefined,
 ): response is SemesterFetchResponse {
-  return response.success && "timetables" in response;
+  return response?.success === true && "timetables" in response;
+}
+
+function getEverytimeResponseError(
+  response: EverytimeResponse | undefined,
+  fallback: string,
+): string {
+  return response?.success === false ? response.error : fallback;
 }
 
 async function listSemesters(tabId: number): Promise<SemesterListResponse> {
   await ensureContentScript(tabId);
   const response = (await chrome.tabs.sendMessage(tabId, {
     type: "LINKU_EVERYTIME_LIST_SEMESTERS",
-  })) as EverytimeResponse;
+  })) as EverytimeResponse | undefined;
 
   if (!isSemesterListResponse(response) || response.semesters.length === 0) {
     throw new Error("에브리타임의 학기 목록을 확인하지 못했습니다.");
@@ -240,13 +257,14 @@ async function captureRenderedTimetable(
   const response = (await chrome.tabs.sendMessage(tabId, {
     type: "LINKU_EVERYTIME_CAPTURE_CURRENT",
     data: { semester },
-  })) as EverytimeResponse;
+  })) as EverytimeResponse | undefined;
 
   if (!isCurrentTimetableResponse(response)) {
     throw new Error(
-      "error" in response
-        ? response.error
-        : "에브리타임 시간표를 불러오지 못했습니다.",
+      getEverytimeResponseError(
+        response,
+        "에브리타임 시간표를 불러오지 못했습니다.",
+      ),
     );
   }
 
@@ -261,13 +279,14 @@ async function fetchSemestersFromApi(
   const response = (await chrome.tabs.sendMessage(tabId, {
     type: "LINKU_EVERYTIME_FETCH_SEMESTERS",
     data: { semesters },
-  })) as EverytimeResponse;
+  })) as EverytimeResponse | undefined;
 
   if (!isSemesterFetchResponse(response)) {
     throw new Error(
-      "error" in response
-        ? response.error
-        : "에브리타임 시간표 API를 불러오지 못했습니다.",
+      getEverytimeResponseError(
+        response,
+        "에브리타임 시간표 API를 불러오지 못했습니다.",
+      ),
     );
   }
 
@@ -344,7 +363,7 @@ async function getImportSemesterCandidates(
     .sort((left, right) => right.sortKey - left.sortKey);
 
   if (mode === "latest") {
-    const anchor = getLatestSemesterAnchor(new Date());
+    const anchor = getLatestEverytimeSemesterAnchor(new Date());
     return periods
       .filter((period) => period.sortKey <= anchor.sortKey)
       .map((period) => period.label);
@@ -427,7 +446,9 @@ async function importSemesterBatchFromTab(
         keepOwnedTabOpen = true;
         await setPendingImport({
           tabId,
-          createdByLinku,
+          // 로그인 탭을 사용자에게 활성화한 뒤에는 더 이상 임시 탭으로
+          // 취급하지 않는다. 로그인 완료 후 foreground 탭을 닫지 않는다.
+          createdByLinku: false,
           requestedAt: new Date().toISOString(),
           mode,
         });
@@ -581,7 +602,7 @@ export async function handleTimetableImport(
         return importSemesterBatchFromTab(
           pendingImport.tabId,
           pendingImport.createdByLinku,
-          mode,
+          pendingImport.mode,
         );
       }
     } catch {

--- a/src/background/handlers/timetable.ts
+++ b/src/background/handlers/timetable.ts
@@ -1,0 +1,639 @@
+import type {
+  EverytimeTimetable,
+  PendingEverytimeImport,
+  TimetableImportMode,
+  TimetableImportResponse,
+} from "@/types/timetable";
+import { TIMETABLE_STORAGE_KEYS } from "@/types/timetable";
+import {
+  getActiveTimetable,
+  getEverytimeTimetableAssetId,
+  getImportedEverytimeSemesters,
+  markEverytimeSemestersImported,
+  saveEverytimeTimetable,
+  setActiveTimetable,
+} from "@/utils/timetableStorage";
+import { getErrorLogDetails, warnLog } from "@/utils/logger";
+import {
+  getEverytimeSemesterSortKey,
+  parseEverytimeSemester,
+  type EverytimeSemesterPeriod,
+} from "@/utils/everytimeSemester";
+
+const EVERYTIME_TIMETABLE_URL = "https://everytime.kr/timetable";
+const EVERYTIME_TIMETABLE_PATTERN = "https://everytime.kr/timetable*";
+const CONTENT_SCRIPT_PATH = "content/everytime-timetable.js";
+const TAB_LOAD_TIMEOUT_MS = 15_000;
+const RECENT_SEMESTER_COUNT = 4;
+
+interface SemesterListResponse {
+  success: true;
+  semesters: string[];
+  currentSemester?: string;
+}
+
+interface SemesterFetchResponse {
+  success: true;
+  timetables: EverytimeTimetable[];
+  skippedSemesters: string[];
+}
+
+interface CurrentTimetableResponse {
+  success: true;
+  timetable: EverytimeTimetable | null;
+}
+
+interface TimetableSearchResult extends SemesterFetchResponse {
+  searchedSemesters: string[];
+}
+
+interface CaptureFailureResponse {
+  success: false;
+  error: string;
+}
+
+type EverytimeResponse =
+  | SemesterListResponse
+  | SemesterFetchResponse
+  | CurrentTimetableResponse
+  | CaptureFailureResponse
+  | { success: true; ready: true };
+
+const importJobs = new Map<number, Promise<TimetableImportResponse>>();
+
+function hasTimetableData(timetable: EverytimeTimetable | null): timetable is EverytimeTimetable {
+  return (
+    timetable != null &&
+    (timetable.subjects.length > 0 || (timetable.courses?.length ?? 0) > 0)
+  );
+}
+
+function isEverytimeLoginUrl(url?: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    return (
+      parsedUrl.hostname === "account.everytime.kr" ||
+      (parsedUrl.hostname === "everytime.kr" &&
+        parsedUrl.pathname.startsWith("/login"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isEverytimeTimetableUrl(url?: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    return (
+      parsedUrl.hostname === "everytime.kr" &&
+      parsedUrl.pathname.startsWith("/timetable")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getLatestSemesterAnchor(
+  now: Date,
+): Pick<EverytimeSemesterPeriod, "year" | "term" | "sortKey"> {
+  const month = now.getMonth();
+  const term = month < 6 ? "1" : "2";
+
+  return {
+    year: now.getFullYear(),
+    term,
+    // 1학기(1~6월)에는 1학기를, 여름방학(7~8월)에는 다음 정규학기인 2학기를
+    // 첫 항목으로 둔다. 겨울방학(1~2월)은 새해 1학기부터 시작한다.
+    sortKey: getEverytimeSemesterSortKey(now.getFullYear(), term),
+  };
+}
+
+async function getPendingImport(): Promise<PendingEverytimeImport | null> {
+  const stored = await chrome.storage.session.get(
+    TIMETABLE_STORAGE_KEYS.pendingImport,
+  );
+
+  return (
+    (stored[
+      TIMETABLE_STORAGE_KEYS.pendingImport
+    ] as PendingEverytimeImport | undefined) ?? null
+  );
+}
+
+async function setPendingImport(
+  pendingImport: PendingEverytimeImport,
+): Promise<void> {
+  await chrome.storage.session.set({
+    [TIMETABLE_STORAGE_KEYS.pendingImport]: pendingImport,
+  });
+}
+
+async function clearPendingImport(): Promise<void> {
+  await chrome.storage.session.remove(TIMETABLE_STORAGE_KEYS.pendingImport);
+}
+
+async function waitForTabToSettle(tabId: number): Promise<chrome.tabs.Tab> {
+  const currentTab = await chrome.tabs.get(tabId);
+  if (currentTab.status === "complete") {
+    return currentTab;
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      chrome.tabs.onUpdated.removeListener(handleUpdated);
+      reject(new Error("에브리타임 페이지를 불러오는 데 시간이 걸리고 있습니다."));
+    }, TAB_LOAD_TIMEOUT_MS);
+
+    function handleUpdated(
+      updatedTabId: number,
+      changeInfo: chrome.tabs.OnUpdatedInfo,
+      updatedTab: chrome.tabs.Tab,
+    ): void {
+      if (updatedTabId !== tabId || changeInfo.status !== "complete") {
+        return;
+      }
+
+      clearTimeout(timeoutId);
+      chrome.tabs.onUpdated.removeListener(handleUpdated);
+      resolve(updatedTab);
+    }
+
+    chrome.tabs.onUpdated.addListener(handleUpdated);
+  });
+}
+
+async function ensureContentScript(tabId: number): Promise<void> {
+  try {
+    const response = (await chrome.tabs.sendMessage(tabId, {
+      type: "LINKU_EVERYTIME_CAPTURE_PING",
+    })) as EverytimeResponse;
+
+    if (response.success) {
+      return;
+    }
+  } catch {
+    // Existing tabs opened before an extension reload need one explicit injection.
+  }
+
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    files: [CONTENT_SCRIPT_PATH],
+  });
+
+  await chrome.tabs.sendMessage(tabId, {
+    type: "LINKU_EVERYTIME_CAPTURE_PING",
+  });
+}
+
+async function closeOwnedTab(tabId: number): Promise<void> {
+  try {
+    await chrome.tabs.remove(tabId);
+  } catch {
+    // The user may have closed the temporary login tab first.
+  }
+}
+
+function isSemesterListResponse(
+  response: EverytimeResponse,
+): response is SemesterListResponse {
+  return response.success && "semesters" in response;
+}
+
+function isCurrentTimetableResponse(
+  response: EverytimeResponse,
+): response is CurrentTimetableResponse {
+  return response.success && "timetable" in response;
+}
+
+function isSemesterFetchResponse(
+  response: EverytimeResponse,
+): response is SemesterFetchResponse {
+  return response.success && "timetables" in response;
+}
+
+async function listSemesters(tabId: number): Promise<SemesterListResponse> {
+  await ensureContentScript(tabId);
+  const response = (await chrome.tabs.sendMessage(tabId, {
+    type: "LINKU_EVERYTIME_LIST_SEMESTERS",
+  })) as EverytimeResponse;
+
+  if (!isSemesterListResponse(response) || response.semesters.length === 0) {
+    throw new Error("에브리타임의 학기 목록을 확인하지 못했습니다.");
+  }
+
+  return response;
+}
+
+async function captureRenderedTimetable(
+  tabId: number,
+  semester: string,
+): Promise<EverytimeTimetable | null> {
+  await ensureContentScript(tabId);
+  const response = (await chrome.tabs.sendMessage(tabId, {
+    type: "LINKU_EVERYTIME_CAPTURE_CURRENT",
+    data: { semester },
+  })) as EverytimeResponse;
+
+  if (!isCurrentTimetableResponse(response)) {
+    throw new Error(
+      "error" in response
+        ? response.error
+        : "에브리타임 시간표를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.timetable;
+}
+
+async function fetchSemestersFromApi(
+  tabId: number,
+  semesters: string[],
+): Promise<SemesterFetchResponse> {
+  await ensureContentScript(tabId);
+  const response = (await chrome.tabs.sendMessage(tabId, {
+    type: "LINKU_EVERYTIME_FETCH_SEMESTERS",
+    data: { semesters },
+  })) as EverytimeResponse;
+
+  if (!isSemesterFetchResponse(response)) {
+    throw new Error(
+      "error" in response
+        ? response.error
+        : "에브리타임 시간표 API를 불러오지 못했습니다.",
+    );
+  }
+
+  return response;
+}
+
+function getSemesterUrl(semester: string): string | null {
+  const period = parseEverytimeSemester(semester);
+  if (!period) {
+    return null;
+  }
+
+  return `${EVERYTIME_TIMETABLE_URL}/${period.year}/${encodeURIComponent(period.term)}`;
+}
+
+async function captureSemesterInTemporaryTab(
+  semester: string,
+): Promise<EverytimeTimetable | null> {
+  const url = getSemesterUrl(semester);
+  if (!url) {
+    return null;
+  }
+
+  const tab = await chrome.tabs.create({ url, active: false });
+  if (tab.id == null) {
+    throw new Error("에브리타임 시간표 탭을 열지 못했습니다.");
+  }
+
+  try {
+    const loadedTab = await waitForTabToSettle(tab.id);
+    if (isEverytimeLoginUrl(loadedTab.url)) {
+      throw new Error("에브리타임 로그인이 필요합니다.");
+    }
+
+    if (!isEverytimeTimetableUrl(loadedTab.url)) {
+      return null;
+    }
+
+    return await captureRenderedTimetable(tab.id, semester);
+  } finally {
+    await closeOwnedTab(tab.id);
+  }
+}
+
+async function captureSemesterBatch(
+  semesters: string[],
+): Promise<SemesterFetchResponse> {
+  const captures = await Promise.all(
+    semesters.map(async (semester) => ({
+      semester,
+      timetable: await captureSemesterInTemporaryTab(semester),
+    })),
+  );
+  const timetables = captures
+    .map(({ timetable }) => timetable)
+    .filter(hasTimetableData);
+
+  return {
+    success: true,
+    timetables,
+    skippedSemesters: captures
+      .filter(({ timetable }) => !hasTimetableData(timetable))
+      .map(({ semester }) => semester),
+  };
+}
+
+async function getImportSemesterCandidates(
+  mode: TimetableImportMode,
+  list: SemesterListResponse,
+): Promise<string[]> {
+  const periods = list.semesters
+    .map(parseEverytimeSemester)
+    .filter((period): period is EverytimeSemesterPeriod => period != null)
+    .sort((left, right) => right.sortKey - left.sortKey);
+
+  if (mode === "latest") {
+    const anchor = getLatestSemesterAnchor(new Date());
+    return periods
+      .filter((period) => period.sortKey <= anchor.sortKey)
+      .map((period) => period.label);
+  }
+
+  const importedSemesters = await getImportedEverytimeSemesters();
+  const importedPeriods = importedSemesters
+    .map(parseEverytimeSemester)
+    .filter((period): period is EverytimeSemesterPeriod => period != null);
+  if (importedPeriods.length === 0) {
+    return [];
+  }
+
+  const oldestImportedSortKey = Math.min(
+    ...importedPeriods.map((period) => period.sortKey),
+  );
+  return periods
+    .filter((period) => period.sortKey < oldestImportedSortKey)
+    .map((period) => period.label);
+}
+
+async function findFirstPopulatedSemesterBatch(
+  tabId: number,
+  semesterCandidates: string[],
+): Promise<TimetableSearchResult | null> {
+  const searchedSemesters: string[] = [];
+  const skippedSemesters: string[] = [];
+
+  for (
+    let startIndex = 0;
+    startIndex < semesterCandidates.length;
+    startIndex += RECENT_SEMESTER_COUNT
+  ) {
+    const semesters = semesterCandidates.slice(
+      startIndex,
+      startIndex + RECENT_SEMESTER_COUNT,
+    );
+    let response: SemesterFetchResponse;
+    try {
+      response = await fetchSemestersFromApi(tabId, semesters);
+    } catch (error) {
+      warnLog(
+        "[Timetable] Everytime API unavailable; using rendered DOM fallback",
+        getErrorLogDetails(error),
+      );
+      response = await captureSemesterBatch(semesters);
+    }
+
+    searchedSemesters.push(...semesters);
+    skippedSemesters.push(...response.skippedSemesters);
+
+    if (response.timetables.length > 0) {
+      return {
+        ...response,
+        skippedSemesters,
+        searchedSemesters,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function importSemesterBatchFromTab(
+  tabId: number,
+  createdByLinku: boolean,
+  mode: TimetableImportMode,
+): Promise<TimetableImportResponse> {
+  const existingJob = importJobs.get(tabId);
+  if (existingJob) {
+    return existingJob;
+  }
+
+  const job = (async (): Promise<TimetableImportResponse> => {
+    let keepOwnedTabOpen = false;
+
+    try {
+      const sourceTab = await waitForTabToSettle(tabId);
+      if (isEverytimeLoginUrl(sourceTab.url)) {
+        keepOwnedTabOpen = true;
+        await setPendingImport({
+          tabId,
+          createdByLinku,
+          requestedAt: new Date().toISOString(),
+          mode,
+        });
+        await chrome.tabs.update(tabId, { active: true });
+
+        return {
+          success: false,
+          code: "LOGIN_REQUIRED",
+          error: "열린 에브리타임 탭에서 로그인하면 시간표를 자동으로 가져옵니다.",
+          loginTabId: tabId,
+        };
+      }
+
+      if (!isEverytimeTimetableUrl(sourceTab.url)) {
+        return {
+          success: false,
+          code: "TAB_UNAVAILABLE",
+          error: "에브리타임 시간표 페이지를 열 수 없습니다.",
+        };
+      }
+
+      const semesterList = await listSemesters(tabId);
+      const semesterCandidates = await getImportSemesterCandidates(
+        mode,
+        semesterList,
+      );
+      if (semesterCandidates.length === 0) {
+        return {
+          success: false,
+          code: "NO_PREVIOUS_SEMESTERS",
+          error:
+            mode === "previous"
+              ? "더 이전의 시간표가 없습니다."
+              : "가져올 최신 시간표가 없습니다.",
+        };
+      }
+
+      const response = await findFirstPopulatedSemesterBatch(
+        tabId,
+        semesterCandidates,
+      );
+      if (!response) {
+        return {
+          success: false,
+          code: "TIMETABLE_NOT_FOUND",
+          error:
+            mode === "previous"
+              ? "더 이전 학기에서 수업이 있는 시간표를 찾지 못했습니다."
+              : "에브리타임에 저장된 시간표를 찾지 못했습니다.",
+        };
+      }
+
+      const existingActiveTimetable = await getActiveTimetable();
+      const results: Array<
+        Awaited<ReturnType<typeof saveEverytimeTimetable>>
+      > = [];
+      for (const timetable of response.timetables) {
+        // Each save performs a read-modify-write on the shared asset index.
+        // Keep this sequential so concurrent semester saves cannot overwrite
+        // one another while appending to the collection.
+        results.push(await saveEverytimeTimetable(timetable));
+      }
+      const activeSemester = semesterList.currentSemester;
+      const activeTimetable =
+        response.timetables.find(
+          (timetable) => timetable.semester === activeSemester,
+        ) ?? response.timetables[0];
+      if (!existingActiveTimetable && activeTimetable) {
+        await setActiveTimetable(
+          getEverytimeTimetableAssetId(activeTimetable.semester),
+        );
+      }
+
+      await Promise.all([
+        markEverytimeSemestersImported(response.searchedSemesters),
+        clearPendingImport(),
+      ]);
+
+      return {
+        success: true,
+        activeAssetId:
+          existingActiveTimetable?.meta.id ??
+          (activeTimetable
+            ? getEverytimeTimetableAssetId(activeTimetable.semester)
+            : null),
+        importedCount: response.timetables.length,
+        updatedCount: results.filter((result) => result.changed).length,
+        skippedCount: response.skippedSemesters.length,
+      };
+    } catch (error) {
+      warnLog(
+        "[Timetable] Everytime import failed",
+        getErrorLogDetails(error),
+      );
+
+      return {
+        success: false,
+        code: "CAPTURE_FAILED",
+        error:
+          error instanceof Error
+            ? error.message
+            : "에브리타임 시간표를 가져오지 못했습니다.",
+      };
+    } finally {
+      if (createdByLinku && !keepOwnedTabOpen) {
+        await closeOwnedTab(tabId);
+      }
+    }
+  })();
+
+  importJobs.set(tabId, job);
+
+  try {
+    return await job;
+  } finally {
+    importJobs.delete(tabId);
+  }
+}
+
+async function findExistingTimetableTab(): Promise<chrome.tabs.Tab | null> {
+  const tabs = await chrome.tabs.query({
+    url: [EVERYTIME_TIMETABLE_PATTERN],
+  });
+
+  return (
+    tabs
+      .filter((tab): tab is chrome.tabs.Tab & { id: number } => tab.id != null)
+      .sort(
+        (left, right) =>
+          (right.lastAccessed ?? 0) - (left.lastAccessed ?? 0),
+      )[0] ?? null
+  );
+}
+
+export async function handleTimetableImport(
+  mode: TimetableImportMode = "latest",
+): Promise<TimetableImportResponse> {
+  const existingTab = await findExistingTimetableTab();
+  if (existingTab?.id != null) {
+    return importSemesterBatchFromTab(existingTab.id, false, mode);
+  }
+
+  const pendingImport = await getPendingImport();
+  if (pendingImport) {
+    try {
+      const pendingTab = await chrome.tabs.get(pendingImport.tabId);
+      if (
+        isEverytimeLoginUrl(pendingTab.url) ||
+        isEverytimeTimetableUrl(pendingTab.url)
+      ) {
+        return importSemesterBatchFromTab(
+          pendingImport.tabId,
+          pendingImport.createdByLinku,
+          mode,
+        );
+      }
+    } catch {
+      await clearPendingImport();
+    }
+  }
+
+  const createdTab = await chrome.tabs.create({
+    url: EVERYTIME_TIMETABLE_URL,
+    active: false,
+  });
+
+  if (createdTab.id == null) {
+    return {
+      success: false,
+      code: "TAB_UNAVAILABLE",
+      error: "에브리타임 탭을 열지 못했습니다.",
+    };
+  }
+
+  return importSemesterBatchFromTab(createdTab.id, true, mode);
+}
+
+export async function handlePendingImportTabUpdated(
+  tabId: number,
+  changeInfo: chrome.tabs.OnUpdatedInfo,
+  tab: chrome.tabs.Tab,
+): Promise<void> {
+  if (changeInfo.status !== "complete") {
+    return;
+  }
+
+  const pendingImport = await getPendingImport();
+  if (
+    pendingImport?.tabId !== tabId ||
+    !isEverytimeTimetableUrl(tab.url)
+  ) {
+    return;
+  }
+
+  await importSemesterBatchFromTab(
+    tabId,
+    pendingImport.createdByLinku,
+    pendingImport.mode,
+  );
+}
+
+export async function handlePendingImportTabRemoved(
+  tabId: number,
+): Promise<void> {
+  const pendingImport = await getPendingImport();
+  if (pendingImport?.tabId === tabId) {
+    await clearPendingImport();
+  }
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -12,16 +12,38 @@ import {
   BackgroundMessageType,
   isGoogleLoginMessage,
   isSilentReauthMessage,
+  isTimetableImportMessage,
 } from "./types";
 import { debugLog, getErrorLogDetails, warnLog } from "@/utils/logger";
 import type {
   BackgroundMessage,
   GoogleLoginResponse,
   SilentReauthResponse,
+  TimetableImportResponse,
 } from "./types";
 import { handleGoogleLogin } from "./handlers/oauth";
+import {
+  handlePendingImportTabRemoved,
+  handlePendingImportTabUpdated,
+  handleTimetableImport,
+} from "./handlers/timetable";
 
 debugLog("[Background] Service worker initialized");
+
+async function restrictLocalStorageAccess(): Promise<void> {
+  try {
+    await chrome.storage.local.setAccessLevel({
+      accessLevel: "TRUSTED_CONTEXTS",
+    });
+  } catch (error) {
+    warnLog(
+      "[Background] Failed to restrict local storage access",
+      getErrorLogDetails(error),
+    );
+  }
+}
+
+void restrictLocalStorageAccess();
 
 /**
  * Message handler for popup -> background communication
@@ -110,6 +132,29 @@ chrome.runtime.onMessage.addListener(
       return true;
     }
 
+    if (isTimetableImportMessage(typedMessage)) {
+      handleTimetableImport(typedMessage.data?.mode)
+        .then((response: TimetableImportResponse) => {
+          sendResponse(response);
+        })
+        .catch((error: unknown) => {
+          warnLog(
+            "[Background] Timetable import handler error",
+            getErrorLogDetails(error),
+          );
+          sendResponse({
+            success: false,
+            code: "UNKNOWN",
+            error:
+              error instanceof Error
+                ? error.message
+                : "시간표를 가져오지 못했습니다.",
+          } satisfies TimetableImportResponse);
+        });
+
+      return true;
+    }
+
     // Unknown message type
     const unknownType = (message as { type: string }).type;
     warnLog("[Background] Unknown message type", { type: unknownType });
@@ -140,6 +185,27 @@ chrome.runtime.onInstalled.addListener((details) => {
  */
 chrome.runtime.onStartup.addListener(() => {
   debugLog("[Background] Browser started, service worker activated");
+  void restrictLocalStorageAccess();
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  handlePendingImportTabUpdated(tabId, changeInfo, tab).catch(
+    (error: unknown) => {
+      warnLog(
+        "[Background] Pending timetable import resume failed",
+        getErrorLogDetails(error),
+      );
+    },
+  );
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  handlePendingImportTabRemoved(tabId).catch((error: unknown) => {
+    warnLog(
+      "[Background] Pending timetable import cleanup failed",
+      getErrorLogDetails(error),
+    );
+  });
 });
 
 /**
@@ -173,5 +239,10 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 });
 
 // Export for type checking (not used at runtime)
-export type { BackgroundMessage, GoogleLoginResponse, SilentReauthResponse };
+export type {
+  BackgroundMessage,
+  GoogleLoginResponse,
+  SilentReauthResponse,
+  TimetableImportResponse,
+};
 export { BackgroundMessageType };

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -4,6 +4,10 @@
  */
 
 import type { GoogleOAuthResponse } from '../types/api';
+import type {
+  TimetableImportMode,
+  TimetableImportResponse,
+} from '../types/timetable';
 
 /**
  * Message types for popup -> background communication
@@ -11,6 +15,7 @@ import type { GoogleOAuthResponse } from '../types/api';
 export enum BackgroundMessageType {
   GOOGLE_LOGIN = 'GOOGLE_LOGIN',
   SILENT_REAUTH = 'SILENT_REAUTH',
+  TIMETABLE_IMPORT = 'TIMETABLE_IMPORT',
 }
 
 /**
@@ -82,3 +87,20 @@ export function isSilentReauthMessage(
 ): message is SilentReauthMessage {
   return message.type === BackgroundMessageType.SILENT_REAUTH;
 }
+
+/**
+ * Requests a one-off import from an existing Everytime timetable tab.
+ * When no matching tab exists, the background worker opens one temporarily.
+ */
+export interface TimetableImportMessage extends BackgroundMessage {
+  type: BackgroundMessageType.TIMETABLE_IMPORT;
+  data?: { mode?: TimetableImportMode };
+}
+
+export function isTimetableImportMessage(
+  message: BackgroundMessage,
+): message is TimetableImportMessage {
+  return message.type === BackgroundMessageType.TIMETABLE_IMPORT;
+}
+
+export type { TimetableImportResponse };

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -100,7 +100,20 @@ export interface TimetableImportMessage extends BackgroundMessage {
 export function isTimetableImportMessage(
   message: BackgroundMessage,
 ): message is TimetableImportMessage {
-  return message.type === BackgroundMessageType.TIMETABLE_IMPORT;
+  if (message.type !== BackgroundMessageType.TIMETABLE_IMPORT) {
+    return false;
+  }
+
+  if (message.data === undefined) {
+    return true;
+  }
+
+  if (typeof message.data !== "object" || message.data === null) {
+    return false;
+  }
+
+  const mode = (message.data as { mode?: unknown }).mode;
+  return mode === undefined || mode === "latest" || mode === "previous";
 }
 
 export type { TimetableImportResponse };

--- a/src/components/Tabs/LinkGroup.tsx
+++ b/src/components/Tabs/LinkGroup.tsx
@@ -47,7 +47,7 @@ const GridItem = ({ item, colNum }) => {
       }}
     >
       <div className="w-9 h-9 rounded-full bg-main/10 flex items-center justify-center shrink-0">
-        {item.type === "png" ? (
+        {item.type === "png" || item.type === "svg" ? (
           <img
             src={item.icon}
             alt={`${item.label} 이미지`}

--- a/src/components/Tabs/TimeTable/EverytimeSchedule.tsx
+++ b/src/components/Tabs/TimeTable/EverytimeSchedule.tsx
@@ -1,0 +1,206 @@
+import React, { useMemo } from "react";
+import { EverytimeSubjectCard } from "@/components/Tabs/TimeTable/EverytimeSubjectCard";
+import type {
+  EverytimeSubject,
+  EverytimeTimetable,
+} from "@/types/timetable";
+
+const GRID_INTERVAL_HEIGHT_PX = 25;
+const HOUR_HEIGHT_PX = GRID_INTERVAL_HEIGHT_PX * 2;
+const VIEWPORT_PADDING_PX = GRID_INTERVAL_HEIGHT_PX;
+const MIN_TIMETABLE_HEIGHT_PX = GRID_INTERVAL_HEIGHT_PX * 6;
+const DEFAULT_VISIBLE_WEEKDAY_COUNT = 5;
+const TIME_AXIS_WIDTH_PX = 38;
+const GRID_LINE_HEIGHT_PX = 1;
+const GRID_LINE_START_PX = GRID_INTERVAL_HEIGHT_PX - GRID_LINE_HEIGHT_PX;
+const GRID_LINE_COLOR = "rgb(244 244 245)";
+const GRID_BACKGROUND_IMAGE = `repeating-linear-gradient(
+  to bottom,
+  transparent 0,
+  transparent ${GRID_LINE_START_PX}px,
+  ${GRID_LINE_COLOR} ${GRID_LINE_START_PX}px,
+  ${GRID_LINE_COLOR} ${GRID_INTERVAL_HEIGHT_PX}px
+)`;
+
+interface TimetableViewport {
+  height: number;
+  start: number;
+}
+
+interface TimeLabel {
+  hour: number;
+  label: string;
+}
+
+function getTimetableViewport(timetable: EverytimeTimetable): TimetableViewport {
+  if (timetable.subjects.length === 0) {
+    return {
+      start: 0,
+      height: Math.max(
+        MIN_TIMETABLE_HEIGHT_PX,
+        timetable.slotCount * GRID_INTERVAL_HEIGHT_PX,
+      ),
+    };
+  }
+
+  const firstSubjectTop = Math.min(
+    ...timetable.subjects.map((subject) => subject.top),
+  );
+  const lastSubjectBottom = Math.max(
+    ...timetable.subjects.map((subject) => subject.top + subject.height),
+  );
+  const start = Math.max(
+    0,
+    Math.floor((firstSubjectTop - VIEWPORT_PADDING_PX) / HOUR_HEIGHT_PX) *
+      HOUR_HEIGHT_PX,
+  );
+  const end =
+    Math.ceil((lastSubjectBottom + VIEWPORT_PADDING_PX) / HOUR_HEIGHT_PX) *
+    HOUR_HEIGHT_PX;
+
+  return {
+    start,
+    height: Math.max(MIN_TIMETABLE_HEIGHT_PX, end - start),
+  };
+}
+
+function groupSubjectsByDay(
+  subjects: EverytimeSubject[],
+  weekdayCount: number,
+): EverytimeSubject[][] {
+  const groupedSubjects = Array.from(
+    { length: weekdayCount },
+    (): EverytimeSubject[] => [],
+  );
+
+  subjects.forEach((subject) => {
+    groupedSubjects[subject.dayIndex]?.push(subject);
+  });
+
+  return groupedSubjects;
+}
+
+function getVisibleWeekdays(timetable: EverytimeTimetable): string[] {
+  const lastScheduledDayIndex = Math.max(
+    -1,
+    ...timetable.subjects.map((subject) => subject.dayIndex),
+  );
+  const visibleWeekdayCount = Math.min(
+    timetable.weekdays.length,
+    Math.max(DEFAULT_VISIBLE_WEEKDAY_COUNT, lastScheduledDayIndex + 1),
+  );
+
+  return timetable.weekdays.slice(0, visibleWeekdayCount);
+}
+
+function getTimeLabels(viewport: TimetableViewport): TimeLabel[] {
+  const startHour = viewport.start / HOUR_HEIGHT_PX;
+  const hourCount = Math.ceil(viewport.height / HOUR_HEIGHT_PX);
+
+  return Array.from({ length: hourCount }, (_, index) => {
+    const hour = startHour + index;
+    return {
+      hour,
+      label: `${String(hour).padStart(2, "0")}:00`,
+    };
+  });
+}
+
+interface EverytimeScheduleProps {
+  timetable: EverytimeTimetable;
+}
+
+function EverytimeScheduleComponent({ timetable }: EverytimeScheduleProps) {
+  const viewport = useMemo(
+    () => getTimetableViewport(timetable),
+    [timetable],
+  );
+  const visibleWeekdays = useMemo(
+    () => getVisibleWeekdays(timetable),
+    [timetable],
+  );
+  const subjectsByDay = useMemo(
+    () => groupSubjectsByDay(timetable.subjects, visibleWeekdays.length),
+    [timetable.subjects, visibleWeekdays.length],
+  );
+  const timeLabels = useMemo(() => getTimeLabels(viewport), [viewport]);
+  const scheduleGridStyle = useMemo(
+    () => ({
+      gridTemplateColumns: `${TIME_AXIS_WIDTH_PX}px repeat(${visibleWeekdays.length}, minmax(0, 1fr))`,
+    }),
+    [visibleWeekdays.length],
+  );
+
+  if (timetable.subjects.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border bg-neutral-50 px-6 text-center text-sm leading-[1.5] text-muted-foreground">
+        이 학기에는 표시할 수업이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-neutral-200/70 bg-white">
+      <div className="flex min-h-full w-full flex-col bg-white">
+        <div
+          className="sticky top-0 z-10 grid shrink-0 border-b border-neutral-200/70 bg-white text-sm font-medium leading-[1.5] text-neutral-700"
+          style={scheduleGridStyle}
+        >
+          <div
+            className="border-r border-neutral-200/70 px-0.5 py-1.5 text-center text-[10px] font-normal text-neutral-500"
+            aria-hidden="true"
+          >
+            시간
+          </div>
+          {visibleWeekdays.map((weekday) => (
+            <div
+              key={weekday}
+              className="border-r border-neutral-200/70 px-1 py-1.5 text-center last:border-r-0"
+            >
+              {weekday}
+            </div>
+          ))}
+        </div>
+        <div
+          className="grid flex-1"
+          style={{
+            ...scheduleGridStyle,
+            minHeight: `${viewport.height}px`,
+          }}
+        >
+          <div
+            className="h-full border-r border-neutral-200/70 bg-neutral-50/50"
+            aria-hidden="true"
+          >
+            {timeLabels.map((time) => (
+              <div
+                key={time.hour}
+                className="border-b border-neutral-100 px-0.5 pt-1 text-center text-[10px] font-normal leading-none text-neutral-500 last:border-b-0"
+                style={{ height: `${HOUR_HEIGHT_PX}px` }}
+              >
+                {time.label}
+              </div>
+            ))}
+          </div>
+          {visibleWeekdays.map((weekday, dayIndex) => (
+            <div
+              key={weekday}
+              className="relative h-full border-r border-neutral-200/70 last:border-r-0"
+              style={{ backgroundImage: GRID_BACKGROUND_IMAGE }}
+            >
+              {subjectsByDay[dayIndex]?.map((subject) => (
+                <EverytimeSubjectCard
+                  key={subject.id}
+                  subject={subject}
+                  viewportStart={viewport.start}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const EverytimeSchedule = React.memo(EverytimeScheduleComponent);

--- a/src/components/Tabs/TimeTable/EverytimeSchedule.tsx
+++ b/src/components/Tabs/TimeTable/EverytimeSchedule.tsx
@@ -32,6 +32,11 @@ interface TimeLabel {
   label: string;
 }
 
+interface GroupedSubjects {
+  days: EverytimeSubject[][];
+  invalidSubjectCount: number;
+}
+
 function getTimetableViewport(timetable: EverytimeTimetable): TimetableViewport {
   if (timetable.subjects.length === 0) {
     return {
@@ -67,17 +72,24 @@ function getTimetableViewport(timetable: EverytimeTimetable): TimetableViewport 
 function groupSubjectsByDay(
   subjects: EverytimeSubject[],
   weekdayCount: number,
-): EverytimeSubject[][] {
+): GroupedSubjects {
   const groupedSubjects = Array.from(
     { length: weekdayCount },
     (): EverytimeSubject[] => [],
   );
 
+  let invalidSubjectCount = 0;
   subjects.forEach((subject) => {
-    groupedSubjects[subject.dayIndex]?.push(subject);
+    const day = groupedSubjects[subject.dayIndex];
+    if (!day) {
+      invalidSubjectCount += 1;
+      return;
+    }
+
+    day.push(subject);
   });
 
-  return groupedSubjects;
+  return { days: groupedSubjects, invalidSubjectCount };
 }
 
 function getVisibleWeekdays(timetable: EverytimeTimetable): string[] {
@@ -119,7 +131,7 @@ function EverytimeScheduleComponent({ timetable }: EverytimeScheduleProps) {
     () => getVisibleWeekdays(timetable),
     [timetable],
   );
-  const subjectsByDay = useMemo(
+  const groupedSubjects = useMemo(
     () => groupSubjectsByDay(timetable.subjects, visibleWeekdays.length),
     [timetable.subjects, visibleWeekdays.length],
   );
@@ -152,9 +164,9 @@ function EverytimeScheduleComponent({ timetable }: EverytimeScheduleProps) {
           >
             시간
           </div>
-          {visibleWeekdays.map((weekday) => (
+          {visibleWeekdays.map((weekday, dayIndex) => (
             <div
-              key={weekday}
+              key={`${weekday}:${dayIndex}`}
               className="border-r border-neutral-200/70 px-1 py-1.5 text-center last:border-r-0"
             >
               {weekday}
@@ -184,20 +196,27 @@ function EverytimeScheduleComponent({ timetable }: EverytimeScheduleProps) {
           </div>
           {visibleWeekdays.map((weekday, dayIndex) => (
             <div
-              key={weekday}
+              key={`${weekday}:${dayIndex}`}
               className="relative h-full border-r border-neutral-200/70 last:border-r-0"
               style={{ backgroundImage: GRID_BACKGROUND_IMAGE }}
             >
-              {subjectsByDay[dayIndex]?.map((subject) => (
+              {groupedSubjects.days[dayIndex].map((subject) => (
                 <EverytimeSubjectCard
                   key={subject.id}
                   subject={subject}
+                  weekday={weekday}
                   viewportStart={viewport.start}
                 />
               ))}
             </div>
           ))}
         </div>
+        {groupedSubjects.invalidSubjectCount > 0 && (
+          <p className="shrink-0 border-t border-neutral-200/70 px-2 py-1 text-xs leading-[1.5] text-amber-700">
+            요일 정보가 잘못된 수업 {groupedSubjects.invalidSubjectCount}개는
+            표시하지 못했습니다.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/components/Tabs/TimeTable/EverytimeSubjectCard.tsx
+++ b/src/components/Tabs/TimeTable/EverytimeSubjectCard.tsx
@@ -1,0 +1,218 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { EverytimeSubjectTooltip } from "@/components/Tabs/TimeTable/EverytimeSubjectTooltip";
+import { cn } from "@/lib/utils";
+import type { EverytimeSubject } from "@/types/timetable";
+import type { EverytimeSubjectColor } from "@/utils/everytimeTimetableColor";
+
+const SUBJECT_COLOR_CLASS_NAMES: Record<string, string> = {
+  color1: "bg-red-100 text-red-950",
+  color2: "bg-rose-100 text-rose-950",
+  color3: "bg-lime-100 text-lime-950",
+  color4: "bg-emerald-100 text-emerald-950",
+  color5: "bg-sky-100 text-sky-950",
+  color6: "bg-violet-100 text-violet-950",
+  color7: "bg-orange-100 text-orange-950",
+  color8: "bg-amber-100 text-amber-950",
+  color9: "bg-cyan-100 text-cyan-950",
+  color10: "bg-blue-100 text-blue-950",
+  color11: "bg-fuchsia-100 text-fuchsia-950",
+  color12: "bg-teal-100 text-teal-950",
+  color13: "bg-yellow-100 text-yellow-950",
+  color14: "bg-green-100 text-green-950",
+  color15: "bg-indigo-100 text-indigo-950",
+  color16: "bg-pink-100 text-pink-950",
+} satisfies Record<EverytimeSubjectColor, string>;
+
+const FALLBACK_SUBJECT_COLOR_CLASS_NAME = "bg-neutral-200 text-neutral-900";
+const SUBJECT_TITLE_MAX_HEIGHT_EM = 2.4;
+const OVERFLOW_TOLERANCE_PX = 1;
+const TOOLTIP_HOVER_DELAY_MS = 300;
+
+function useSubjectContentOverflow(
+  title: string,
+  subjectHeight: number,
+  detailLineCount: number,
+) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLParagraphElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    const viewport = viewportRef.current;
+    const titleElement = titleRef.current;
+
+    if (!content || !viewport || !titleElement) {
+      return;
+    }
+
+    const updateOverflow = () => {
+      const titleOverflows =
+        titleElement.scrollHeight - viewport.clientHeight >
+        OVERFLOW_TOLERANCE_PX;
+      const contentOverflows =
+        content.scrollHeight - content.clientHeight > OVERFLOW_TOLERANCE_PX;
+
+      setHasOverflow(titleOverflows || contentOverflows);
+    };
+
+    updateOverflow();
+
+    const resizeObserver = new ResizeObserver(updateOverflow);
+    resizeObserver.observe(content);
+    resizeObserver.observe(viewport);
+    resizeObserver.observe(titleElement);
+
+    return () => resizeObserver.disconnect();
+  }, [detailLineCount, subjectHeight, title]);
+
+  return { contentRef, hasOverflow, titleRef, viewportRef };
+}
+
+function getSubjectDescription(subject: EverytimeSubject): string {
+  const fallbackDetail =
+    !subject.professor && !subject.place ? subject.detail : undefined;
+
+  return [
+    subject.title,
+    subject.professor ? `담당 ${subject.professor}` : undefined,
+    subject.place ? `강의실 ${subject.place}` : undefined,
+    fallbackDetail,
+    subject.timeText,
+    subject.credit !== undefined ? `${subject.credit}학점` : undefined,
+    subject.isClosed ? "폐강" : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function getSubjectDetailLines(subject: EverytimeSubject): string[] {
+  const structuredDetails = [subject.professor, subject.place].filter(
+    (detail): detail is string => Boolean(detail),
+  );
+
+  if (structuredDetails.length > 0) {
+    return structuredDetails;
+  }
+
+  return subject.detail ? [subject.detail] : [];
+}
+
+interface EverytimeSubjectCardProps {
+  subject: EverytimeSubject;
+  viewportStart: number;
+}
+
+export function EverytimeSubjectCard({
+  subject,
+  viewportStart,
+}: EverytimeSubjectCardProps) {
+  const description = getSubjectDescription(subject);
+  const detailLines = getSubjectDetailLines(subject);
+  const articleRef = useRef<HTMLElement>(null);
+  const tooltipTimerRef = useRef<number | null>(null);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const { contentRef, hasOverflow, titleRef, viewportRef } =
+    useSubjectContentOverflow(
+      subject.title,
+      subject.height,
+      detailLines.length,
+    );
+
+  const clearTooltipTimer = () => {
+    if (tooltipTimerRef.current !== null) {
+      window.clearTimeout(tooltipTimerRef.current);
+      tooltipTimerRef.current = null;
+    }
+  };
+
+  const openTooltipAfterDelay = () => {
+    if (!hasOverflow) {
+      return;
+    }
+
+    clearTooltipTimer();
+    tooltipTimerRef.current = window.setTimeout(() => {
+      setIsTooltipOpen(true);
+      tooltipTimerRef.current = null;
+    }, TOOLTIP_HOVER_DELAY_MS);
+  };
+
+  const closeTooltip = () => {
+    clearTooltipTimer();
+    setIsTooltipOpen(false);
+  };
+
+  useEffect(
+    () => () => {
+      if (tooltipTimerRef.current !== null) {
+        window.clearTimeout(tooltipTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  return (
+    <>
+      <article
+        ref={articleRef}
+        className={cn(
+          "absolute inset-x-0 overflow-hidden border-y border-white/70 px-1 py-px text-sm font-medium leading-[1.2] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-main/60",
+          SUBJECT_COLOR_CLASS_NAMES[subject.color] ??
+            FALLBACK_SUBJECT_COLOR_CLASS_NAME,
+        )}
+        style={{
+          top: `${subject.top - viewportStart}px`,
+          height: `${subject.height}px`,
+        }}
+        tabIndex={hasOverflow ? 0 : undefined}
+        aria-label={description}
+        onMouseEnter={openTooltipAfterDelay}
+        onMouseLeave={closeTooltip}
+        onFocus={() => hasOverflow && setIsTooltipOpen(true)}
+        onBlur={closeTooltip}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            closeTooltip();
+          }
+        }}
+      >
+        <div
+          ref={contentRef}
+          className="flex h-full min-h-0 flex-col overflow-hidden"
+        >
+          <div
+            ref={viewportRef}
+            className="min-h-0 shrink overflow-hidden"
+            style={{ maxHeight: `${SUBJECT_TITLE_MAX_HEIGHT_EM}em` }}
+          >
+            <p ref={titleRef} className="break-words">
+              {subject.title}
+            </p>
+          </div>
+          {detailLines.map((detail, index) => (
+            <p
+              key={`${subject.id}:detail:${index}`}
+              className="shrink-0 truncate font-normal text-xs leading-[1.2]"
+            >
+              {detail}
+            </p>
+          ))}
+        </div>
+      </article>
+
+      <EverytimeSubjectTooltip
+        anchorRef={articleRef}
+        detailLines={detailLines}
+        open={hasOverflow && isTooltipOpen}
+        subject={subject}
+      />
+    </>
+  );
+}

--- a/src/components/Tabs/TimeTable/EverytimeSubjectCard.tsx
+++ b/src/components/Tabs/TimeTable/EverytimeSubjectCard.tsx
@@ -75,15 +75,32 @@ function useSubjectContentOverflow(
   return { contentRef, hasOverflow, titleRef, viewportRef };
 }
 
-function getSubjectDescription(subject: EverytimeSubject): string {
+function formatEverytimeTime(time: number): string {
+  const minutes = time * 5;
+  const hour = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+function getSubjectDescription(
+  subject: EverytimeSubject,
+  weekday: string,
+): string {
   const fallbackDetail =
     !subject.professor && !subject.place ? subject.detail : undefined;
+  const meetingTime =
+    subject.startTime !== undefined && subject.endTime !== undefined
+      ? `${weekday}요일 ${formatEverytimeTime(subject.startTime)}–${formatEverytimeTime(subject.endTime)}`
+      : weekday
+        ? `${weekday}요일`
+        : undefined;
 
   return [
     subject.title,
     subject.professor ? `담당 ${subject.professor}` : undefined,
     subject.place ? `강의실 ${subject.place}` : undefined,
     fallbackDetail,
+    meetingTime,
     subject.timeText,
     subject.credit !== undefined ? `${subject.credit}학점` : undefined,
     subject.isClosed ? "폐강" : undefined,
@@ -106,14 +123,16 @@ function getSubjectDetailLines(subject: EverytimeSubject): string[] {
 
 interface EverytimeSubjectCardProps {
   subject: EverytimeSubject;
+  weekday: string;
   viewportStart: number;
 }
 
 export function EverytimeSubjectCard({
   subject,
+  weekday,
   viewportStart,
 }: EverytimeSubjectCardProps) {
-  const description = getSubjectDescription(subject);
+  const description = getSubjectDescription(subject, weekday);
   const detailLines = getSubjectDetailLines(subject);
   const articleRef = useRef<HTMLElement>(null);
   const tooltipTimerRef = useRef<number | null>(null);

--- a/src/components/Tabs/TimeTable/EverytimeSubjectTooltip.tsx
+++ b/src/components/Tabs/TimeTable/EverytimeSubjectTooltip.tsx
@@ -4,6 +4,10 @@ import type { EverytimeSubject } from "@/types/timetable";
 
 const TOOLTIP_GAP_PX = 8;
 const VIEWPORT_PADDING_PX = 8;
+const PASSIVE_CAPTURE_LISTENER_OPTIONS = {
+  capture: true,
+  passive: true,
+} as const;
 
 interface EverytimeSubjectTooltipProps {
   anchorRef: RefObject<HTMLElement | null>;
@@ -61,7 +65,11 @@ export function EverytimeSubjectTooltip({
 
     updatePosition();
     window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener(
+      "scroll",
+      updatePosition,
+      PASSIVE_CAPTURE_LISTENER_OPTIONS,
+    );
 
     return () => {
       window.removeEventListener("resize", updatePosition);

--- a/src/components/Tabs/TimeTable/EverytimeSubjectTooltip.tsx
+++ b/src/components/Tabs/TimeTable/EverytimeSubjectTooltip.tsx
@@ -1,0 +1,102 @@
+import { useLayoutEffect, useRef, type RefObject } from "react";
+import { createPortal } from "react-dom";
+import type { EverytimeSubject } from "@/types/timetable";
+
+const TOOLTIP_GAP_PX = 8;
+const VIEWPORT_PADDING_PX = 8;
+
+interface EverytimeSubjectTooltipProps {
+  anchorRef: RefObject<HTMLElement | null>;
+  detailLines: string[];
+  open: boolean;
+  subject: EverytimeSubject;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function EverytimeSubjectTooltip({
+  anchorRef,
+  detailLines,
+  open,
+  subject,
+}: EverytimeSubjectTooltipProps) {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const detailText = detailLines.join("\n");
+
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current;
+    const tooltip = tooltipRef.current;
+    if (!open || !anchor || !tooltip) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const anchorRect = anchor.getBoundingClientRect();
+      const tooltipWidth = tooltip.offsetWidth;
+      const tooltipHeight = tooltip.offsetHeight;
+      const maxLeft = Math.max(
+        VIEWPORT_PADDING_PX,
+        window.innerWidth - tooltipWidth - VIEWPORT_PADDING_PX,
+      );
+      const left = clamp(
+        anchorRect.left + anchorRect.width / 2 - tooltipWidth / 2,
+        VIEWPORT_PADDING_PX,
+        maxLeft,
+      );
+      const spaceBelow = window.innerHeight - anchorRect.bottom;
+      const top =
+        spaceBelow >= tooltipHeight + TOOLTIP_GAP_PX + VIEWPORT_PADDING_PX
+          ? anchorRect.bottom + TOOLTIP_GAP_PX
+          : Math.max(
+              VIEWPORT_PADDING_PX,
+              anchorRect.top - tooltipHeight - TOOLTIP_GAP_PX,
+            );
+
+      tooltip.style.left = `${left}px`;
+      tooltip.style.top = `${top}px`;
+      tooltip.style.visibility = "visible";
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [anchorRef, detailText, open, subject.title]);
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      aria-hidden="true"
+      data-everytime-subject-tooltip=""
+      className="pointer-events-none fixed z-[100] w-60 max-w-[calc(100vw-1rem)] rounded-md border border-neutral-300 bg-white px-3 py-2.5 text-left text-neutral-950 shadow-xl"
+      style={{ visibility: "hidden" }}
+    >
+      <p className="break-words text-[15px] font-semibold leading-[1.5]">
+        {subject.title}
+      </p>
+      {detailLines.map((detail, index) => (
+        <p
+          key={`${subject.id}:tooltip-detail:${index}`}
+          className={
+            index === 0
+              ? "mt-1.5 text-sm leading-[1.5] text-neutral-700"
+              : "text-sm leading-[1.5] text-neutral-700"
+          }
+        >
+          {detail}
+        </p>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/Tabs/TimeTable/TimeTable.tsx
+++ b/src/components/Tabs/TimeTable/TimeTable.tsx
@@ -26,6 +26,7 @@ import { TimetableActionButton } from "@/components/Tabs/TimeTable/TimetableActi
 import { EverytimeSchedule } from "@/components/Tabs/TimeTable/EverytimeSchedule";
 import { TimetableSavedActions } from "@/components/Tabs/TimeTable/TimetableSavedActions";
 import { sortTimetableAssetsBySemester } from "@/components/Tabs/TimeTable/timetableAssetSorting";
+import { TIMETABLE_IMAGE_ACCEPT } from "@/components/Tabs/TimeTable/timetableImage";
 import { useBlobObjectUrl } from "@/hooks/useBlobObjectUrl";
 import { type TimetableBusyState, useTimetable } from "@/hooks/useTimetable";
 import { cn } from "@/lib/utils";
@@ -227,7 +228,7 @@ const FileInput = ({ inputRef, onChange }: FileInputProps) => (
   <input
     ref={inputRef}
     type="file"
-    accept="image/png,.png"
+    accept={TIMETABLE_IMAGE_ACCEPT}
     className="sr-only"
     onChange={onChange}
   />
@@ -317,7 +318,7 @@ const Empty = ({
           ) : (
             <ImageUp />
           )}
-          PNG 파일 올리기
+          시간표 이미지 올리기
         </TimetableActionButton>
       </div>
       <p className="mt-4 text-sm leading-[1.5] text-muted-foreground">
@@ -371,7 +372,7 @@ const Saved = ({
             >
               {sortedAssets.map((storedAsset) => (
                 <option key={storedAsset.id} value={storedAsset.id}>
-                  {storedAsset.semester ?? "PNG 시간표"}
+                  {storedAsset.semester ?? "시간표 이미지"}
                 </option>
               ))}
             </select>

--- a/src/components/Tabs/TimeTable/TimeTable.tsx
+++ b/src/components/Tabs/TimeTable/TimeTable.tsx
@@ -25,7 +25,10 @@ import {
 import { TimetableActionButton } from "@/components/Tabs/TimeTable/TimetableActionButton";
 import { EverytimeSchedule } from "@/components/Tabs/TimeTable/EverytimeSchedule";
 import { TimetableSavedActions } from "@/components/Tabs/TimeTable/TimetableSavedActions";
-import { sortTimetableAssetsBySemester } from "@/components/Tabs/TimeTable/timetableAssetSorting";
+import {
+  getTimetableAssetLabel,
+  sortTimetableAssetsBySemester,
+} from "@/components/Tabs/TimeTable/timetableAssetSorting";
 import { TIMETABLE_IMAGE_ACCEPT } from "@/components/Tabs/TimeTable/timetableImage";
 import { useBlobObjectUrl } from "@/hooks/useBlobObjectUrl";
 import { type TimetableBusyState, useTimetable } from "@/hooks/useTimetable";
@@ -366,13 +369,12 @@ const Saved = ({
             <select
               className="h-8 w-full min-w-0 rounded-md border border-neutral-300 bg-white px-2 text-sm font-semibold text-neutral-900 outline-none focus-visible:ring-2 focus-visible:ring-main/50"
               value={asset.meta.id}
-              aria-label="저장된 시간표 선택"
               disabled={isBusy}
               onChange={(event) => onSelect(event.target.value)}
             >
               {sortedAssets.map((storedAsset) => (
                 <option key={storedAsset.id} value={storedAsset.id}>
-                  {storedAsset.semester ?? "시간표 이미지"}
+                  {getTimetableAssetLabel(storedAsset)}
                 </option>
               ))}
             </select>

--- a/src/components/Tabs/TimeTable/TimeTable.tsx
+++ b/src/components/Tabs/TimeTable/TimeTable.tsx
@@ -1,0 +1,493 @@
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+} from "react";
+import {
+  CalendarDays,
+  ImageUp,
+  LoaderCircle,
+} from "lucide-react";
+import EverytimeSymbolUrl from "@/assets/everytime_symbol.svg";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TimetableActionButton } from "@/components/Tabs/TimeTable/TimetableActionButton";
+import { EverytimeSchedule } from "@/components/Tabs/TimeTable/EverytimeSchedule";
+import { TimetableSavedActions } from "@/components/Tabs/TimeTable/TimetableSavedActions";
+import { sortTimetableAssetsBySemester } from "@/components/Tabs/TimeTable/timetableAssetSorting";
+import { useBlobObjectUrl } from "@/hooks/useBlobObjectUrl";
+import { type TimetableBusyState, useTimetable } from "@/hooks/useTimetable";
+import { cn } from "@/lib/utils";
+import type {
+  ResolvedTimetableAsset,
+  TimetableAssetMeta,
+} from "@/types/timetable";
+
+interface FileInputProps {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+interface EverytimeImportButtonProps {
+  label: string;
+  busy: TimetableBusyState;
+  disabled: boolean;
+  onImport: () => void;
+}
+
+interface AcademicInfoImportButtonProps {
+  className?: string;
+}
+
+interface EmptyProps {
+  isDragging: boolean;
+  busy: TimetableBusyState;
+  onImport: () => void;
+  onUpload: () => void;
+}
+
+interface SavedProps {
+  asset: ResolvedTimetableAsset;
+  assets: TimetableAssetMeta[];
+  imageUrl: string | null;
+  busy: TimetableBusyState;
+  onImport: () => void;
+  onImportPreviousSemesters: () => void;
+  onUpload: () => void;
+  onPreview: () => void;
+  onDelete: () => void;
+  onSelect: (id: string) => void;
+}
+
+interface PreviewDialogProps {
+  asset: ResolvedTimetableAsset | null;
+  imageUrl: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface DeleteDialogProps {
+  open: boolean;
+  isDeleting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+}
+
+const TimeTableRoot = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const {
+    asset,
+    assets,
+    busy,
+    saveUploadedFile,
+    importLatestEverytime,
+    importPreviousEverytimeSemesters,
+    deleteTimetable,
+    selectTimetable,
+  } = useTimetable();
+  const imageUrl = useBlobObjectUrl(
+    asset?.kind === "upload" ? asset.blob : undefined,
+  );
+
+  const saveSelectedFile = useCallback(
+    (file: File) => {
+      void saveUploadedFile(file).finally(() => {
+        if (inputRef.current) {
+          inputRef.current.value = "";
+        }
+      });
+    },
+    [saveUploadedFile],
+  );
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        saveSelectedFile(file);
+      }
+    },
+    [saveSelectedFile],
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+
+      const file = event.dataTransfer.files[0];
+      if (file && !busy) {
+        saveSelectedFile(file);
+      }
+    },
+    [busy, saveSelectedFile],
+  );
+
+  const handleEverytimeImport = useCallback(() => {
+    void importLatestEverytime();
+  }, [importLatestEverytime]);
+
+  const handlePreviousSemestersImport = useCallback(() => {
+    void importPreviousEverytimeSemesters();
+  }, [importPreviousEverytimeSemesters]);
+
+  const openFilePicker = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const openPreview = useCallback(() => {
+    setIsPreviewOpen(true);
+  }, []);
+
+  const openDeleteDialog = useCallback(() => {
+    setIsDeleteOpen(true);
+  }, []);
+
+  const handleDelete = useCallback(() => {
+    void deleteTimetable().then((deleted) => {
+      if (deleted) {
+        setIsDeleteOpen(false);
+      }
+    });
+  }, [deleteTimetable]);
+
+  return (
+    <section
+      className="h-[400px] border-t bg-white"
+      aria-label="시간표"
+      onDragEnter={(event) => {
+        event.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragOver={(event) => event.preventDefault()}
+      onDragLeave={(event) => {
+        if (event.currentTarget === event.target) {
+          setIsDragging(false);
+        }
+      }}
+      onDrop={handleDrop}
+    >
+      <FileInput inputRef={inputRef} onChange={handleFileChange} />
+
+      {busy === "loading" ? (
+        <Loading />
+      ) : asset ? (
+        <Saved
+          asset={asset}
+          assets={assets}
+          imageUrl={imageUrl}
+          busy={busy}
+          onImport={handleEverytimeImport}
+          onImportPreviousSemesters={handlePreviousSemestersImport}
+          onUpload={openFilePicker}
+          onPreview={openPreview}
+          onDelete={openDeleteDialog}
+          onSelect={selectTimetable}
+        />
+      ) : (
+        <Empty
+          isDragging={isDragging}
+          busy={busy}
+          onImport={handleEverytimeImport}
+          onUpload={openFilePicker}
+        />
+      )}
+
+      <PreviewDialog
+        asset={asset}
+        imageUrl={imageUrl}
+        open={isPreviewOpen}
+        onOpenChange={setIsPreviewOpen}
+      />
+      <DeleteDialog
+        open={isDeleteOpen}
+        isDeleting={busy === "deleting"}
+        onOpenChange={setIsDeleteOpen}
+        onDelete={handleDelete}
+      />
+    </section>
+  );
+};
+
+const FileInput = ({ inputRef, onChange }: FileInputProps) => (
+  <input
+    ref={inputRef}
+    type="file"
+    accept="image/png,.png"
+    className="sr-only"
+    onChange={onChange}
+  />
+);
+
+const Loading = () => (
+  <div className="flex h-full flex-col items-center justify-center gap-3">
+    <LoaderCircle className="size-7 animate-spin text-main" />
+    <p className="text-sm leading-[1.5] text-muted-foreground">
+      저장된 시간표를 불러오는 중이에요
+    </p>
+  </div>
+);
+
+const EverytimeImportButton = ({
+  label,
+  busy,
+  disabled,
+  onImport,
+}: EverytimeImportButtonProps) => (
+  <TimetableActionButton type="button" disabled={disabled} onClick={onImport}>
+    {busy === "importing" ? (
+      <LoaderCircle className="animate-spin" />
+    ) : (
+      <img
+        src={EverytimeSymbolUrl}
+        alt=""
+        aria-hidden="true"
+        className="size-5"
+      />
+    )}
+    {label}
+  </TimetableActionButton>
+);
+
+const AcademicInfoImportButton = ({ className }: AcademicInfoImportButtonProps) => (
+  <TimetableActionButton
+    type="button"
+    className={className}
+    disabled
+    aria-label="학사정보시스템에서 가져오기 준비 중"
+  >
+    <CalendarDays />
+    학사정보시스템에서 가져오기
+  </TimetableActionButton>
+);
+
+const Empty = ({
+  isDragging,
+  busy,
+  onImport,
+  onUpload,
+}: EmptyProps) => {
+  const isBusy = busy !== null;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col items-center justify-center px-8 text-center transition-colors",
+        isDragging && "bg-main/5",
+      )}
+    >
+      <div className="mb-4 flex size-14 items-center justify-center rounded-2xl bg-main/10 text-main">
+        {busy === "uploading" || busy === "importing" ? (
+          <LoaderCircle className="size-7 animate-spin" />
+        ) : (
+          <CalendarDays className="size-7" />
+        )}
+      </div>
+      <h2 className="text-lg font-semibold leading-[1.5]">
+        내 시간표를 바로 확인하세요
+      </h2>
+      <p className="mt-2 max-w-[350px] text-sm leading-[1.65] text-muted-foreground">
+        로그인된 에브리타임 탭이 있으면 자동으로 가져옵니다.
+      </p>
+      <div className="mt-5 flex w-full max-w-[330px] flex-col gap-2">
+        <EverytimeImportButton
+          label="에브리타임에서 가져오기"
+          busy={busy}
+          disabled={isBusy}
+          onImport={onImport}
+        />
+        <AcademicInfoImportButton />
+        <TimetableActionButton type="button" disabled={isBusy} onClick={onUpload}>
+          {busy === "uploading" ? (
+            <LoaderCircle className="animate-spin" />
+          ) : (
+            <ImageUp />
+          )}
+          PNG 파일 올리기
+        </TimetableActionButton>
+      </div>
+      <p className="mt-4 text-sm leading-[1.5] text-muted-foreground">
+        이미지는 서버가 아닌 이 브라우저에만 저장됩니다
+      </p>
+    </div>
+  );
+};
+
+const Saved = ({
+  asset,
+  assets,
+  imageUrl,
+  busy,
+  onImport,
+  onImportPreviousSemesters,
+  onUpload,
+  onPreview,
+  onDelete,
+  onSelect,
+}: SavedProps) => {
+  const isBusy = busy !== null;
+  const isUploadedImage = asset.kind === "upload";
+  const sortedAssets = useMemo(
+    () => sortTimetableAssetsBySemester(assets),
+    [assets],
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col",
+        isUploadedImage ? "gap-0 bg-white p-0" : "gap-2 p-2",
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2",
+          isUploadedImage && "p-2",
+        )}
+      >
+        {assets.length > 1 ? (
+          <label className="min-w-0 flex-1">
+            <span className="sr-only">저장된 시간표 선택</span>
+            <select
+              className="h-8 w-full min-w-0 rounded-md border border-neutral-300 bg-white px-2 text-sm font-semibold text-neutral-900 outline-none focus-visible:ring-2 focus-visible:ring-main/50"
+              value={asset.meta.id}
+              aria-label="저장된 시간표 선택"
+              disabled={isBusy}
+              onChange={(event) => onSelect(event.target.value)}
+            >
+              {sortedAssets.map((storedAsset) => (
+                <option key={storedAsset.id} value={storedAsset.id}>
+                  {storedAsset.semester ?? "PNG 시간표"}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <h2 className="min-w-0 flex-1 truncate text-base font-semibold leading-[1.5]">
+            {asset.meta.semester ?? "내 시간표"}
+          </h2>
+        )}
+
+        <TimetableSavedActions
+          busy={busy}
+          source={asset.meta.source}
+          onImport={onImport}
+          onImportPreviousSemesters={onImportPreviousSemesters}
+          onUpload={onUpload}
+          onDelete={onDelete}
+        />
+      </div>
+
+      {asset.kind === "everytime" ? (
+        <EverytimeSchedule timetable={asset.timetable} />
+      ) : imageUrl ? (
+        <button
+          type="button"
+          className="m-0 min-h-0 flex-1 overflow-hidden border-0 bg-white p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-main/50"
+          onClick={onPreview}
+          aria-label="시간표 크게 보기"
+        >
+          <img
+            src={imageUrl}
+            alt="업로드한 시간표"
+            className="m-0 block size-full object-contain"
+          />
+        </button>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border bg-neutral-50 px-6 text-center text-sm leading-[1.5] text-muted-foreground">
+          업로드한 시간표 이미지를 불러오지 못했습니다.
+        </div>
+      )}
+    </div>
+  );
+};
+
+const PreviewDialog = ({
+  asset,
+  imageUrl,
+  open,
+  onOpenChange,
+}: PreviewDialogProps) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="max-h-[560px] max-w-[468px] p-4">
+      <DialogHeader>
+        <DialogTitle>{asset?.meta.semester ?? "내 시간표"}</DialogTitle>
+        <DialogDescription>
+          저장된 원본 비율로 시간표를 확인할 수 있어요.
+        </DialogDescription>
+      </DialogHeader>
+      {imageUrl && (
+        <div className="max-h-[450px] overflow-auto bg-white">
+          <img
+            src={imageUrl}
+            alt="확대된 내 시간표"
+            className="m-0 block h-auto w-full"
+          />
+        </div>
+      )}
+    </DialogContent>
+  </Dialog>
+);
+
+const DeleteDialog = ({
+  open,
+  isDeleting,
+  onOpenChange,
+  onDelete,
+}: DeleteDialogProps) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="max-w-[420px]">
+      <DialogHeader>
+        <DialogTitle>저장된 시간표를 삭제할까요?</DialogTitle>
+        <DialogDescription>
+          현재 보고 있는 시간표만 삭제합니다. 다른 시간표는 그대로 유지됩니다.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button type="button" variant="outline" disabled={isDeleting}>
+            취소
+          </Button>
+        </DialogClose>
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={isDeleting}
+          onClick={onDelete}
+        >
+          {isDeleting && <LoaderCircle className="animate-spin" />}
+          삭제
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);
+
+const TimeTable = Object.assign(React.memo(TimeTableRoot), {
+  FileInput: React.memo(FileInput),
+  Loading: React.memo(Loading),
+  EverytimeImportButton: React.memo(EverytimeImportButton),
+  AcademicInfoImportButton: React.memo(AcademicInfoImportButton),
+  Empty: React.memo(Empty),
+  Saved: React.memo(Saved),
+  EverytimeSchedule,
+  SavedActions: TimetableSavedActions,
+  PreviewDialog: React.memo(PreviewDialog),
+  DeleteDialog: React.memo(DeleteDialog),
+});
+
+export default TimeTable;

--- a/src/components/Tabs/TimeTable/TimetableActionButton.tsx
+++ b/src/components/Tabs/TimeTable/TimetableActionButton.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type TimetableActionButtonProps = Omit<
+  ComponentProps<typeof Button>,
+  "variant"
+>;
+
+export function TimetableActionButton({
+  className,
+  ...props
+}: TimetableActionButtonProps) {
+  return (
+    <Button
+      variant="outline"
+      className={cn(
+        "w-full border-neutral-300 bg-white text-neutral-900 hover:bg-neutral-50 hover:text-neutral-900",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/Tabs/TimeTable/TimetableSavedActions.tsx
+++ b/src/components/Tabs/TimeTable/TimetableSavedActions.tsx
@@ -77,7 +77,7 @@ function TimetableSavedActionsComponent({
         <DropdownMenuContent align="end" className="w-52">
           <DropdownMenuItem onSelect={onUpload}>
             <ImageUp />
-            PNG 시간표 올리기
+            시간표 이미지 올리기
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onImportPreviousSemesters}>
             <CalendarDays />

--- a/src/components/Tabs/TimeTable/TimetableSavedActions.tsx
+++ b/src/components/Tabs/TimeTable/TimetableSavedActions.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import {
+  CalendarDays,
+  Ellipsis,
+  ImageUp,
+  LoaderCircle,
+  Trash2,
+} from "lucide-react";
+import EverytimeSymbolUrl from "@/assets/everytime_symbol.svg";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { TimetableBusyState } from "@/hooks/useTimetable";
+import type { TimetableSource } from "@/types/timetable";
+
+interface TimetableSavedActionsProps {
+  busy: TimetableBusyState;
+  source: TimetableSource;
+  onDelete: () => void;
+  onImport: () => void;
+  onImportPreviousSemesters: () => void;
+  onUpload: () => void;
+}
+
+function TimetableSavedActionsComponent({
+  busy,
+  source,
+  onDelete,
+  onImport,
+  onImportPreviousSemesters,
+  onUpload,
+}: TimetableSavedActionsProps) {
+  const isBusy = busy !== null;
+  const importLabel = source === "everytime" ? "동기화" : "에타 가져오기";
+
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 border-neutral-300 bg-white px-2.5 text-neutral-900 hover:bg-neutral-50 hover:text-neutral-900"
+        disabled={isBusy}
+        onClick={onImport}
+      >
+        {busy === "importing" ? (
+          <LoaderCircle className="animate-spin" />
+        ) : (
+          <img
+            src={EverytimeSymbolUrl}
+            alt=""
+            aria-hidden="true"
+            className="size-4"
+          />
+        )}
+        {importLabel}
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            aria-label="시간표 더보기"
+            disabled={isBusy}
+          >
+            <Ellipsis />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuItem onSelect={onUpload}>
+            <ImageUp />
+            PNG 시간표 올리기
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onImportPreviousSemesters}>
+            <CalendarDays />
+            이전 4학기 추가
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onSelect={onDelete}
+          >
+            <Trash2 />
+            현재 시간표 삭제
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+export const TimetableSavedActions = React.memo(
+  TimetableSavedActionsComponent,
+);

--- a/src/components/Tabs/TimeTable/timetableAssetSorting.ts
+++ b/src/components/Tabs/TimeTable/timetableAssetSorting.ts
@@ -4,6 +4,13 @@ import {
   parseEverytimeSemester,
 } from "@/utils/everytimeSemester";
 
+const UPLOADED_TIMETABLE_DATE_FORMATTER = new Intl.DateTimeFormat("ko-KR", {
+  month: "numeric",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
 function getAssetSemesterSortKey(asset: TimetableAssetMeta): number | null {
   if (asset.source === "everytime") {
     const semesterMetadata = asset.snapshot.semesterMetadata;
@@ -44,4 +51,15 @@ export function sortTimetableAssetsBySemester(
   assets: readonly TimetableAssetMeta[],
 ): TimetableAssetMeta[] {
   return [...assets].sort(compareTimetableAssetsBySemester);
+}
+
+export function getTimetableAssetLabel(asset: TimetableAssetMeta): string {
+  if (asset.semester) {
+    return asset.semester;
+  }
+
+  const createdAt = new Date(asset.createdAt);
+  return Number.isNaN(createdAt.getTime())
+    ? "시간표 이미지"
+    : `시간표 이미지 · ${UPLOADED_TIMETABLE_DATE_FORMATTER.format(createdAt)}`;
 }

--- a/src/components/Tabs/TimeTable/timetableAssetSorting.ts
+++ b/src/components/Tabs/TimeTable/timetableAssetSorting.ts
@@ -1,0 +1,47 @@
+import type { TimetableAssetMeta } from "@/types/timetable";
+import {
+  getEverytimeSemesterSortKey,
+  parseEverytimeSemester,
+} from "@/utils/everytimeSemester";
+
+function getAssetSemesterSortKey(asset: TimetableAssetMeta): number | null {
+  if (asset.source === "everytime") {
+    const semesterMetadata = asset.snapshot.semesterMetadata;
+    if (semesterMetadata) {
+      return getEverytimeSemesterSortKey(
+        semesterMetadata.year,
+        semesterMetadata.term,
+      );
+    }
+  }
+
+  return asset.semester
+    ? (parseEverytimeSemester(asset.semester)?.sortKey ?? null)
+    : null;
+}
+
+function compareTimetableAssetsBySemester(
+  left: TimetableAssetMeta,
+  right: TimetableAssetMeta,
+): number {
+  const leftSortKey = getAssetSemesterSortKey(left);
+  const rightSortKey = getAssetSemesterSortKey(right);
+
+  if (leftSortKey !== null && rightSortKey !== null) {
+    return rightSortKey - leftSortKey;
+  }
+  if (leftSortKey !== null) {
+    return -1;
+  }
+  if (rightSortKey !== null) {
+    return 1;
+  }
+
+  return right.updatedAt.localeCompare(left.updatedAt);
+}
+
+export function sortTimetableAssetsBySemester(
+  assets: readonly TimetableAssetMeta[],
+): TimetableAssetMeta[] {
+  return [...assets].sort(compareTimetableAssetsBySemester);
+}

--- a/src/components/Tabs/TimeTable/timetableImage.ts
+++ b/src/components/Tabs/TimeTable/timetableImage.ts
@@ -1,0 +1,58 @@
+const BYTES_PER_MEBIBYTE = 1024 * 1024;
+const MAX_TIMETABLE_IMAGE_SIZE_MB = 8;
+const PNG_FILE_SIGNATURE = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10,
+]);
+
+export const TIMETABLE_PNG_REQUIREMENTS = {
+  maxByteSize: MAX_TIMETABLE_IMAGE_SIZE_MB * BYTES_PER_MEBIBYTE,
+  maxSizeLabel: `${MAX_TIMETABLE_IMAGE_SIZE_MB}MB`,
+  minWidth: 280,
+  minHeight: 180,
+} as const;
+
+export interface TimetablePng {
+  blob: Blob;
+  width: number;
+  height: number;
+}
+
+export async function readTimetablePng(file: File): Promise<TimetablePng> {
+  if (file.size > TIMETABLE_PNG_REQUIREMENTS.maxByteSize) {
+    throw new Error(
+      `${TIMETABLE_PNG_REQUIREMENTS.maxSizeLabel} 이하 PNG 파일을 올려주세요.`,
+    );
+  }
+
+  const bytes = new Uint8Array(
+    await file.slice(0, PNG_FILE_SIGNATURE.byteLength).arrayBuffer(),
+  );
+  const hasPngSignature = PNG_FILE_SIGNATURE.every(
+    (expected, index) => bytes[index] === expected,
+  );
+
+  if (!hasPngSignature) {
+    throw new Error("PNG 형식의 시간표 이미지만 올릴 수 있습니다.");
+  }
+
+  const blob =
+    file.type === "image/png"
+      ? file
+      : new Blob([await file.arrayBuffer()], { type: "image/png" });
+  const bitmap = await createImageBitmap(blob);
+
+  try {
+    const { minWidth, minHeight } = TIMETABLE_PNG_REQUIREMENTS;
+    if (bitmap.width < minWidth || bitmap.height < minHeight) {
+      throw new Error("시간표를 확인할 수 있는 크기의 이미지를 올려주세요.");
+    }
+
+    return {
+      blob,
+      width: bitmap.width,
+      height: bitmap.height,
+    };
+  } finally {
+    bitmap.close();
+  }
+}

--- a/src/components/Tabs/TimeTable/timetableImage.ts
+++ b/src/components/Tabs/TimeTable/timetableImage.ts
@@ -1,10 +1,12 @@
 import {
   TIMETABLE_IMAGE_MIME_TYPES,
   type TimetableImageMimeType,
-} from "@/types/timetable";
+} from "../../../types/timetable.ts";
 
 const BYTES_PER_MEBIBYTE = 1024 * 1024;
-const MAX_TIMETABLE_IMAGE_SIZE_MB = 8;
+const MAX_TIMETABLE_IMAGE_SIZE_MB = 5;
+const MAX_TIMETABLE_IMAGE_DIMENSION_PX = 8_192;
+const MAX_TIMETABLE_IMAGE_PIXEL_COUNT = 32_000_000;
 const IMAGE_SIGNATURE_BYTE_LENGTH = 32;
 const SUPPORTED_IMAGE_FORMAT_LABEL = "PNG, JPG, JPEG, WebP, GIF, AVIF";
 const PNG_FILE_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10] as const;
@@ -30,6 +32,9 @@ export const TIMETABLE_IMAGE_ACCEPT = [
 export const TIMETABLE_IMAGE_REQUIREMENTS = {
   maxByteSize: MAX_TIMETABLE_IMAGE_SIZE_MB * BYTES_PER_MEBIBYTE,
   maxSizeLabel: `${MAX_TIMETABLE_IMAGE_SIZE_MB}MB`,
+  maxWidth: MAX_TIMETABLE_IMAGE_DIMENSION_PX,
+  maxHeight: MAX_TIMETABLE_IMAGE_DIMENSION_PX,
+  maxPixelCount: MAX_TIMETABLE_IMAGE_PIXEL_COUNT,
   minWidth: 280,
   minHeight: 180,
   supportedFormatLabel: SUPPORTED_IMAGE_FORMAT_LABEL,
@@ -69,7 +74,7 @@ function includesAlignedBytes(
   return false;
 }
 
-function detectImageMimeType(
+export function detectImageMimeType(
   bytes: Uint8Array,
 ): TimetableImageMimeType | null {
   if (startsWithBytes(bytes, PNG_FILE_SIGNATURE)) {
@@ -140,9 +145,22 @@ export async function readTimetableImage(
   const bitmap = await decodeImage(blob);
 
   try {
-    const { minWidth, minHeight } = TIMETABLE_IMAGE_REQUIREMENTS;
+    const {
+      maxHeight,
+      maxPixelCount,
+      maxWidth,
+      minHeight,
+      minWidth,
+    } = TIMETABLE_IMAGE_REQUIREMENTS;
     if (bitmap.width < minWidth || bitmap.height < minHeight) {
       throw new Error("시간표를 확인할 수 있는 크기의 이미지를 올려주세요.");
+    }
+    if (
+      bitmap.width > maxWidth ||
+      bitmap.height > maxHeight ||
+      bitmap.width * bitmap.height > maxPixelCount
+    ) {
+      throw new Error("해상도가 너무 큰 이미지입니다. 더 작은 이미지를 올려주세요.");
     }
 
     return {

--- a/src/components/Tabs/TimeTable/timetableImage.ts
+++ b/src/components/Tabs/TimeTable/timetableImage.ts
@@ -1,48 +1,146 @@
+import {
+  TIMETABLE_IMAGE_MIME_TYPES,
+  type TimetableImageMimeType,
+} from "@/types/timetable";
+
 const BYTES_PER_MEBIBYTE = 1024 * 1024;
 const MAX_TIMETABLE_IMAGE_SIZE_MB = 8;
-const PNG_FILE_SIGNATURE = new Uint8Array([
-  137, 80, 78, 71, 13, 10, 26, 10,
-]);
+const IMAGE_SIGNATURE_BYTE_LENGTH = 32;
+const SUPPORTED_IMAGE_FORMAT_LABEL = "PNG, JPG, JPEG, WebP, GIF, AVIF";
+const PNG_FILE_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10] as const;
+const JPEG_FILE_SIGNATURE = [255, 216, 255] as const;
+const GIF87A_FILE_SIGNATURE = [71, 73, 70, 56, 55, 97] as const;
+const GIF89A_FILE_SIGNATURE = [71, 73, 70, 56, 57, 97] as const;
+const RIFF_FILE_SIGNATURE = [82, 73, 70, 70] as const;
+const WEBP_FILE_SIGNATURE = [87, 69, 66, 80] as const;
+const FTYP_FILE_SIGNATURE = [102, 116, 121, 112] as const;
+const AVIF_FILE_SIGNATURE = [97, 118, 105, 102] as const;
+const AVIS_FILE_SIGNATURE = [97, 118, 105, 115] as const;
 
-export const TIMETABLE_PNG_REQUIREMENTS = {
+export const TIMETABLE_IMAGE_ACCEPT = [
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".gif",
+  ".avif",
+  ...TIMETABLE_IMAGE_MIME_TYPES,
+].join(",");
+
+export const TIMETABLE_IMAGE_REQUIREMENTS = {
   maxByteSize: MAX_TIMETABLE_IMAGE_SIZE_MB * BYTES_PER_MEBIBYTE,
   maxSizeLabel: `${MAX_TIMETABLE_IMAGE_SIZE_MB}MB`,
   minWidth: 280,
   minHeight: 180,
+  supportedFormatLabel: SUPPORTED_IMAGE_FORMAT_LABEL,
 } as const;
 
-export interface TimetablePng {
+export interface TimetableImage {
   blob: Blob;
   width: number;
   height: number;
 }
 
-export async function readTimetablePng(file: File): Promise<TimetablePng> {
-  if (file.size > TIMETABLE_PNG_REQUIREMENTS.maxByteSize) {
+function startsWithBytes(
+  bytes: Uint8Array,
+  signature: readonly number[],
+  offset = 0,
+): boolean {
+  return signature.every(
+    (expected, index) => bytes[offset + index] === expected,
+  );
+}
+
+function includesAlignedBytes(
+  bytes: Uint8Array,
+  signature: readonly number[],
+  startOffset: number,
+): boolean {
+  for (
+    let offset = startOffset;
+    offset <= bytes.length - signature.length;
+    offset += 4
+  ) {
+    if (startsWithBytes(bytes, signature, offset)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function detectImageMimeType(
+  bytes: Uint8Array,
+): TimetableImageMimeType | null {
+  if (startsWithBytes(bytes, PNG_FILE_SIGNATURE)) {
+    return "image/png";
+  }
+
+  if (startsWithBytes(bytes, JPEG_FILE_SIGNATURE)) {
+    return "image/jpeg";
+  }
+
+  if (
+    startsWithBytes(bytes, GIF87A_FILE_SIGNATURE) ||
+    startsWithBytes(bytes, GIF89A_FILE_SIGNATURE)
+  ) {
+    return "image/gif";
+  }
+
+  if (
+    startsWithBytes(bytes, RIFF_FILE_SIGNATURE) &&
+    startsWithBytes(bytes, WEBP_FILE_SIGNATURE, 8)
+  ) {
+    return "image/webp";
+  }
+
+  if (
+    startsWithBytes(bytes, FTYP_FILE_SIGNATURE, 4) &&
+    (includesAlignedBytes(bytes, AVIF_FILE_SIGNATURE, 8) ||
+      includesAlignedBytes(bytes, AVIS_FILE_SIGNATURE, 8))
+  ) {
+    return "image/avif";
+  }
+
+  return null;
+}
+
+async function decodeImage(blob: Blob): Promise<ImageBitmap> {
+  try {
+    return await createImageBitmap(blob);
+  } catch {
+    throw new Error("손상되었거나 브라우저에서 읽을 수 없는 이미지입니다.");
+  }
+}
+
+export async function readTimetableImage(
+  file: File,
+): Promise<TimetableImage> {
+  if (file.size > TIMETABLE_IMAGE_REQUIREMENTS.maxByteSize) {
     throw new Error(
-      `${TIMETABLE_PNG_REQUIREMENTS.maxSizeLabel} 이하 PNG 파일을 올려주세요.`,
+      `${TIMETABLE_IMAGE_REQUIREMENTS.maxSizeLabel} 이하 이미지를 올려주세요.`,
     );
   }
 
   const bytes = new Uint8Array(
-    await file.slice(0, PNG_FILE_SIGNATURE.byteLength).arrayBuffer(),
+    await file.slice(0, IMAGE_SIGNATURE_BYTE_LENGTH).arrayBuffer(),
   );
-  const hasPngSignature = PNG_FILE_SIGNATURE.every(
-    (expected, index) => bytes[index] === expected,
-  );
+  const mimeType = detectImageMimeType(bytes);
 
-  if (!hasPngSignature) {
-    throw new Error("PNG 형식의 시간표 이미지만 올릴 수 있습니다.");
+  if (!mimeType) {
+    throw new Error(
+      `${TIMETABLE_IMAGE_REQUIREMENTS.supportedFormatLabel} 형식의 이미지를 올려주세요.`,
+    );
   }
 
   const blob =
-    file.type === "image/png"
+    file.type === mimeType
       ? file
-      : new Blob([await file.arrayBuffer()], { type: "image/png" });
-  const bitmap = await createImageBitmap(blob);
+      : new Blob([await file.arrayBuffer()], { type: mimeType });
+  const bitmap = await decodeImage(blob);
 
   try {
-    const { minWidth, minHeight } = TIMETABLE_PNG_REQUIREMENTS;
+    const { minWidth, minHeight } = TIMETABLE_IMAGE_REQUIREMENTS;
     if (bitmap.width < minWidth || bitmap.height < minHeight) {
       throw new Error("시간표를 확인할 수 있는 크기의 이미지를 올려주세요.");
     }

--- a/src/components/TabsLayout.tsx
+++ b/src/components/TabsLayout.tsx
@@ -4,6 +4,7 @@ import LinkGroup from "./Tabs/LinkGroup";
 import TodoList from "./Tabs/TodoList/TodoList";
 import TodoCountBadge from "./Tabs/TodoList/TodoCountBadge";
 import Alerts from "./Tabs/Alerts/Alerts";
+import TimeTable from "./Tabs/TimeTable/TimeTable";
 import { sendTabChange } from "@/utils/analytics";
 import { useSelectedTemplate } from "@/hooks/useSelectedTemplate";
 
@@ -48,9 +49,7 @@ const TabsLayout = () => {
         )}
       </TabsContent>
       <TabsContent value="TimeTable">
-        <div className="size-full border-t text-center">
-          시간표는 준비 중입니다
-        </div>
+        <TimeTable />
       </TabsContent>
       <TabsContent value="TodoList">
         <TodoList />

--- a/src/constants/LinkList.ts
+++ b/src/constants/LinkList.ts
@@ -1,4 +1,5 @@
 import { HelloLmsPng } from "@/assets";
+import EverytimeSymbolUrl from "@/assets/everytime_symbol.svg";
 import {
   BULLETIN_FALLBACK,
   BULLETIN_LINK_ID,
@@ -18,7 +19,6 @@ import {
   Clock,
   Trophy,
   GraduationCap,
-  AlarmClock,
   MapPinned,
   Utensils,
   Building,
@@ -158,8 +158,8 @@ export const LinkList: LinkListElement[] = [
     link: "https://www.konkuk.ac.kr/general/18211/subview.do",
   },
   {
-    icon: AlarmClock,
-    iconColor: "text-red-600",
+    icon: EverytimeSymbolUrl,
+    type: "svg",
     label: "에브리타임",
     link: "https://account.everytime.kr/login",
   },

--- a/src/content/everytime-timetable.ts
+++ b/src/content/everytime-timetable.ts
@@ -1,0 +1,606 @@
+import type {
+  EverytimeCourse,
+  EverytimeSemesterMetadata,
+  EverytimeSemesterTerm,
+  EverytimeSubject,
+  EverytimeTableMetadata,
+  EverytimeTimetable,
+} from "@/types/timetable";
+import {
+  DEFAULT_EVERYTIME_SUBJECT_COLOR,
+  getStableEverytimeSubjectColor,
+  isEverytimeSubjectColor,
+} from "@/utils/everytimeTimetableColor";
+
+type CaptureRequest =
+  | { type: "LINKU_EVERYTIME_CAPTURE_PING" }
+  | { type: "LINKU_EVERYTIME_LIST_SEMESTERS" }
+  | {
+      type: "LINKU_EVERYTIME_CAPTURE_CURRENT";
+      data: { semester: string };
+    }
+  | {
+      type: "LINKU_EVERYTIME_FETCH_SEMESTERS";
+      data: { semesters: string[] };
+    };
+
+type CaptureResponse =
+  | { success: true; ready: true }
+  | { success: true; semesters: string[]; currentSemester?: string }
+  | { success: true; timetable: EverytimeTimetable | null }
+  | { success: true; timetables: EverytimeTimetable[]; skippedSemesters: string[] }
+  | { success: false; error: string };
+
+const EVERYTIME_API_BASE_URL = "https://api.everytime.kr/find/timetable";
+const EVERYTIME_SEMESTER_LIST_URL = `${EVERYTIME_API_BASE_URL}/subject/semester/list`;
+const EVERYTIME_TABLE_LIST_URL = `${EVERYTIME_API_BASE_URL}/table/list/semester`;
+const EVERYTIME_TABLE_DETAIL_URL = `${EVERYTIME_API_BASE_URL}/table`;
+const EVERYTIME_SELECT_SELECTOR = "#semesters";
+const EVERYTIME_TIMETABLE_SELECTOR = "#container.timetable";
+const EVERYTIME_SEMESTER_PATTERN = /^(20\d{2})년\s*(1|2|여름|겨울)학기$/;
+const SEMESTER_FETCH_CONCURRENCY = 4;
+const EVERYTIME_TIME_UNIT_PX = 25 / 6;
+const EVERYTIME_WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"];
+const TIMETABLE_RENDER_TIMEOUT_MS = 5_000;
+
+const linkuWindow = window as Window & {
+  __LINKU_EVERYTIME_CAPTURE_INSTALLED__?: boolean;
+};
+
+if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
+  linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__ = true;
+
+  const exactText = (element: Element | null): string =>
+    element?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+
+  const isEverytimeSemesterTerm = (
+    value?: string,
+  ): value is EverytimeSemesterTerm =>
+    value === "1" || value === "여름" || value === "2" || value === "겨울";
+
+  const formatEverytimeSemester = (
+    year: number,
+    term: EverytimeSemesterTerm,
+  ): string => `${year}년 ${term}학기`;
+
+  const parseEverytimeSemester = (
+    semester: string,
+  ): { year: number; term: EverytimeSemesterTerm } | null => {
+    const match = semester.match(EVERYTIME_SEMESTER_PATTERN);
+    if (!match) {
+      return null;
+    }
+
+    const year = Number.parseInt(match[1], 10);
+    const term = match[2];
+    return isEverytimeSemesterTerm(term) ? { year, term } : null;
+  };
+
+  const findTimetableRoot = (documentRoot: Document = document): HTMLElement | null =>
+    documentRoot.querySelector<HTMLElement>(EVERYTIME_TIMETABLE_SELECTOR);
+
+  const readSemester = (documentRoot: Document = document): string | undefined => {
+    const select = documentRoot.querySelector<HTMLSelectElement>(
+      EVERYTIME_SELECT_SELECTOR,
+    );
+    const selectedOption = select?.selectedOptions.item(0);
+    const selectedSemester = exactText(selectedOption ?? null);
+    if (EVERYTIME_SEMESTER_PATTERN.test(selectedSemester)) {
+      return selectedSemester;
+    }
+
+    if (
+      select?.value &&
+      EVERYTIME_SEMESTER_PATTERN.test(select.value.trim())
+    ) {
+      return select.value.trim();
+    }
+
+    const semesterPattern = /20\d{2}\s*년?\s*(?:1|2|여름|겨울)\s*학기/;
+    const headings = Array.from(documentRoot.querySelectorAll("h1, h2, h3, option"));
+    const match = headings
+      .map((heading) => exactText(heading).match(semesterPattern))
+      .find((candidate) => candidate != null);
+
+    return match?.[0].replace(/\s+/g, " ").trim();
+  };
+
+  const readSemesterOptions = (): string[] => {
+    const select = document.querySelector<HTMLSelectElement>(
+      EVERYTIME_SELECT_SELECTOR,
+    );
+    if (!select) {
+      return [];
+    }
+
+    return Array.from(select.options)
+      .map((option) => option.textContent?.trim() ?? "")
+      .filter((semester) => EVERYTIME_SEMESTER_PATTERN.test(semester));
+  };
+
+  const parsePixel = (value: string | null): number => {
+    const parsed = Number.parseFloat(value ?? "");
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const readAttribute = (
+    element: Element,
+    ...attributeNames: string[]
+  ): string | undefined => {
+    for (const attributeName of attributeNames) {
+      const value = element.getAttribute(attributeName)?.trim();
+      if (value) {
+        return value;
+      }
+    }
+
+    return undefined;
+  };
+
+  const readValue = (element: Element, selector: string): string | undefined => {
+    const valueElement = element.querySelector(selector);
+    return valueElement ? readAttribute(valueElement, "value") : undefined;
+  };
+
+  const parseOptionalNumber = (value?: string): number | undefined => {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+
+  const parseOptionalFlag = (value?: string): boolean | undefined => {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return value === "1";
+  };
+
+  const getColorClass = (subject: Element): string =>
+    Array.from(subject.classList).find(isEverytimeSubjectColor) ??
+    DEFAULT_EVERYTIME_SUBJECT_COLOR;
+
+  const parseTimetable = (
+    documentRoot: Document,
+    expectedSemester: string,
+  ): EverytimeTimetable | null => {
+    const root = findTimetableRoot(documentRoot);
+    const bodyTable = root?.querySelector("table.tablebody");
+    if (!root || !bodyTable) {
+      return null;
+    }
+
+    const weekdays = Array.from(
+      root.querySelectorAll("table.tablehead th, table.tablehead td"),
+    )
+      .map((cell) => exactText(cell))
+      .filter(Boolean)
+      .filter((label) => ["월", "화", "수", "목", "금", "토", "일"].includes(label));
+    const cells = Array.from(bodyTable.querySelectorAll("td"));
+    const subjects: EverytimeSubject[] = [];
+
+    cells.forEach((cell, dayIndex) => {
+      const subjectElements = Array.from(
+        cell.querySelectorAll(":scope > div.cols > div.subject"),
+      );
+
+      subjectElements.forEach((subject, subjectIndex) => {
+        const top = parsePixel(subject.getAttribute("style")?.match(/top:\s*([^;]+)/)?.[1] ?? null);
+        const height = parsePixel(
+          subject.getAttribute("style")?.match(/height:\s*([^;]+)/)?.[1] ?? null,
+        );
+        const title = exactText(subject.querySelector("h3"));
+        if (!title || height <= 0) {
+          return;
+        }
+
+        const detailElement = subject.querySelector("p");
+        const professor = exactText(detailElement?.querySelector("em") ?? null);
+        const rawDetail = exactText(detailElement);
+        const place = professor
+          ? rawDetail.slice(professor.length).trim()
+          : rawDetail;
+
+        subjects.push({
+          id: `${expectedSemester}:${dayIndex}:${top}:${subjectIndex}`,
+          dayIndex,
+          title,
+          professor: professor || undefined,
+          place: place || undefined,
+          detail: [professor, place].filter(Boolean).join(" · ") || undefined,
+          color: getColorClass(subject),
+          top,
+          height,
+        });
+      });
+    });
+
+    const hourGridCount = root.querySelectorAll("table.tablebody div.grids > div.grid").length;
+    return {
+      semester: readSemester(documentRoot) ?? expectedSemester,
+      weekdays,
+      slotCount: Math.max(1, hourGridCount * 2),
+      subjects,
+    };
+  };
+
+  const waitForRenderedTimetable = (
+    semester: string,
+  ): Promise<EverytimeTimetable | null> =>
+    new Promise((resolve) => {
+      const resolveRenderedTimetable = (): boolean => {
+        const timetable = parseTimetable(document, semester);
+        if (timetable?.subjects.length) {
+          cleanup();
+          resolve(timetable);
+          return true;
+        }
+
+        return false;
+      };
+
+      const observer = new MutationObserver(resolveRenderedTimetable);
+      const timeoutId = window.setTimeout(() => {
+        cleanup();
+        resolve(parseTimetable(document, semester));
+      }, TIMETABLE_RENDER_TIMEOUT_MS);
+      const cleanup = (): void => {
+        observer.disconnect();
+        window.clearTimeout(timeoutId);
+      };
+
+      if (resolveRenderedTimetable()) {
+        return;
+      }
+
+      observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    });
+
+  const fetchEverytimeXml = async (
+    url: string,
+    body: URLSearchParams,
+  ): Promise<Document> => {
+    const response = await fetch(url, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/xml, text/xml, */*; q=0.01",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body: body.toString(),
+    });
+    if (!response.ok) {
+      throw new Error("에브리타임 시간표 API를 불러오지 못했습니다.");
+    }
+
+    const documentRoot = new DOMParser().parseFromString(
+      await response.text(),
+      "application/xml",
+    );
+    if (documentRoot.querySelector("parsererror")) {
+      throw new Error("에브리타임 시간표 응답을 해석하지 못했습니다.");
+    }
+
+    return documentRoot;
+  };
+
+  const parseSemesterMetadataList = (
+    documentRoot: Document,
+  ): Map<string, EverytimeSemesterMetadata> => {
+    const metadataBySemester = new Map<string, EverytimeSemesterMetadata>();
+
+    documentRoot.querySelectorAll("response > semester").forEach((semester) => {
+      const year = parseOptionalNumber(readAttribute(semester, "year"));
+      const term = readAttribute(semester, "semester");
+      if (
+        year === undefined ||
+        !Number.isInteger(year) ||
+        !isEverytimeSemesterTerm(term)
+      ) {
+        return;
+      }
+
+      const metadata: EverytimeSemesterMetadata = {
+        year,
+        term,
+        startDate: readAttribute(semester, "start_date"),
+        endDate: readAttribute(semester, "end_date"),
+        isFormal: parseOptionalFlag(readAttribute(semester, "is_formal")),
+        isSupported: parseOptionalFlag(readAttribute(semester, "is_supported")),
+        hasSyllabus: parseOptionalFlag(readAttribute(semester, "has_syllabus")),
+        hasSubjectDatabase: parseOptionalFlag(
+          readAttribute(semester, "has_subject_database"),
+        ),
+        subjectDatabaseUpdatedAt: readAttribute(semester, "updated_at"),
+      };
+      metadataBySemester.set(formatEverytimeSemester(year, term), metadata);
+    });
+
+    return metadataBySemester;
+  };
+
+  const parseTableMetadata = (
+    table: Element,
+    fallback: EverytimeTableMetadata = {},
+  ): EverytimeTableMetadata => {
+    const term = readAttribute(table, "semester");
+    const parsedTerm = isEverytimeSemesterTerm(term) ? term : fallback.term;
+
+    return {
+      id: readAttribute(table, "id") ?? fallback.id,
+      name: readAttribute(table, "name") ?? fallback.name,
+      year: parseOptionalNumber(readAttribute(table, "year")) ?? fallback.year,
+      term: parsedTerm,
+      isDeleted:
+        parseOptionalFlag(readAttribute(table, "is_deleted")) ??
+        fallback.isDeleted,
+      isPrivate:
+        parseOptionalFlag(readAttribute(table, "priv")) ?? fallback.isPrivate,
+      isPrimary:
+        parseOptionalFlag(readAttribute(table, "primary", "is_primary")) ??
+        fallback.isPrimary,
+      createdAt: readAttribute(table, "created_at") ?? fallback.createdAt,
+      updatedAt: readAttribute(table, "updated_at") ?? fallback.updatedAt,
+    };
+  };
+
+  const parseApiTimetable = (
+    documentRoot: Document,
+    semester: string,
+    semesterMetadata?: EverytimeSemesterMetadata,
+    listTableMetadata?: EverytimeTableMetadata,
+  ): EverytimeTimetable | null => {
+    const table = documentRoot.querySelector("response > table");
+    if (!table) {
+      return null;
+    }
+
+    const courses = Array.from(
+      table.querySelectorAll(":scope > subject"),
+    ).flatMap((subject, subjectIndex): EverytimeCourse[] => {
+      const title = readValue(subject, "name");
+      if (!title) {
+        return [];
+      }
+
+      const subjectId = readAttribute(subject, "id");
+      const internalId = readValue(subject, "internal");
+      const professor = readValue(subject, "professor") ?? "";
+      const defaultPlace = readValue(subject, "place") ?? "";
+      const timeText = readValue(subject, "time");
+      const credit = parseOptionalNumber(readValue(subject, "credit"));
+      const isClosed = parseOptionalFlag(readValue(subject, "closed"));
+      const meetings = Array.from(subject.querySelectorAll("time > data")).flatMap(
+        (time) => {
+          const dayIndex = Number.parseInt(time.getAttribute("day") ?? "", 10);
+          const startTime = Number.parseInt(
+            time.getAttribute("starttime") ?? "",
+            10,
+          );
+          const endTime = Number.parseInt(
+            time.getAttribute("endtime") ?? "",
+            10,
+          );
+          if (
+            !Number.isInteger(dayIndex) ||
+            dayIndex < 0 ||
+            dayIndex >= EVERYTIME_WEEKDAYS.length ||
+            !Number.isFinite(startTime) ||
+            !Number.isFinite(endTime) ||
+            endTime <= startTime
+          ) {
+            return [];
+          }
+
+          const place = time.getAttribute("place")?.trim() || defaultPlace;
+          return [
+            {
+              dayIndex,
+              place: place || undefined,
+              startTime,
+              endTime,
+            },
+          ];
+        },
+      );
+
+      return [
+        {
+          id: subjectId ?? `${semester}:course:${subjectIndex}`,
+          internalId,
+          title,
+          professor: professor || undefined,
+          timeText,
+          defaultPlace: defaultPlace || undefined,
+          credit,
+          isClosed,
+          meetings,
+        },
+      ];
+    });
+    const subjects = courses.flatMap((course) =>
+      course.meetings.map((meeting, timeIndex): EverytimeSubject => ({
+        id: `${semester}:${course.id}:${timeIndex}`,
+        subjectId: course.id,
+        internalId: course.internalId,
+        dayIndex: meeting.dayIndex,
+        title: course.title,
+        professor: course.professor,
+        place: meeting.place,
+        defaultPlace: course.defaultPlace,
+        timeText: course.timeText,
+        credit: course.credit,
+        isClosed: course.isClosed,
+        startTime: meeting.startTime,
+        endTime: meeting.endTime,
+        detail:
+          [course.professor, meeting.place].filter(Boolean).join(" · ") ||
+          undefined,
+        color: getStableEverytimeSubjectColor(course.id),
+        top: meeting.startTime * EVERYTIME_TIME_UNIT_PX,
+        height:
+          (meeting.endTime - meeting.startTime) * EVERYTIME_TIME_UNIT_PX,
+      })),
+    );
+
+    return {
+      semester,
+      semesterMetadata,
+      tableMetadata: parseTableMetadata(table, listTableMetadata),
+      courses,
+      weekdays: EVERYTIME_WEEKDAYS,
+      slotCount: 48,
+      subjects,
+    };
+  };
+
+  const fetchSemesterFromApi = async (
+    semester: string,
+    semesterMetadata?: EverytimeSemesterMetadata,
+  ): Promise<EverytimeTimetable | null> => {
+    const period = parseEverytimeSemester(semester);
+    if (!period) {
+      return null;
+    }
+
+    const listDocument = await fetchEverytimeXml(
+      EVERYTIME_TABLE_LIST_URL,
+      new URLSearchParams({
+        year: String(period.year),
+        semester: period.term,
+      }),
+    );
+    const tables = Array.from(listDocument.querySelectorAll("response > table"));
+    const selectedTable =
+      tables.find((table) => table.getAttribute("is_primary") === "1") ??
+      tables[0];
+    if (!selectedTable) {
+      return null;
+    }
+
+    const tableId = selectedTable.getAttribute("id");
+    if (!tableId) {
+      return null;
+    }
+    const listTableMetadata = parseTableMetadata(selectedTable);
+
+    const detailDocument = await fetchEverytimeXml(
+      EVERYTIME_TABLE_DETAIL_URL,
+      new URLSearchParams({ id: tableId }),
+    );
+    return parseApiTimetable(
+      detailDocument,
+      semester,
+      semesterMetadata,
+      listTableMetadata,
+    );
+  };
+
+  const fetchSemestersFromApi = async (
+    semesters: string[],
+  ): Promise<CaptureResponse> => {
+    const requestedSemesters = [...new Set(semesters)].filter(
+      (semester) => parseEverytimeSemester(semester) !== null,
+    );
+    const results: Array<EverytimeTimetable | null> = new Array(
+      requestedSemesters.length,
+    ).fill(null);
+    let nextIndex = 0;
+
+    try {
+      const semesterMetadataDocument = await fetchEverytimeXml(
+        EVERYTIME_SEMESTER_LIST_URL,
+        new URLSearchParams(),
+      );
+      const semesterMetadataByLabel = parseSemesterMetadataList(
+        semesterMetadataDocument,
+      );
+      const workers = Array.from(
+        {
+          length: Math.min(
+            SEMESTER_FETCH_CONCURRENCY,
+            requestedSemesters.length,
+          ),
+        },
+        async () => {
+          while (nextIndex < requestedSemesters.length) {
+            const currentIndex = nextIndex;
+            nextIndex += 1;
+            const requestedSemester = requestedSemesters[currentIndex];
+            results[currentIndex] = await fetchSemesterFromApi(
+              requestedSemester,
+              semesterMetadataByLabel.get(requestedSemester),
+            );
+          }
+        },
+      );
+      await Promise.all(workers);
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "에브리타임 시간표 API를 불러오지 못했습니다.",
+      };
+    }
+
+    const timetables = results.filter(
+      (timetable): timetable is EverytimeTimetable =>
+        timetable != null &&
+        (timetable.subjects.length > 0 || (timetable.courses?.length ?? 0) > 0),
+    );
+    const loadedSemesters = new Set(
+      timetables.map((timetable) => timetable.semester),
+    );
+    return {
+      success: true,
+      timetables,
+      skippedSemesters: requestedSemesters.filter(
+        (semester) => !loadedSemesters.has(semester),
+      ),
+    };
+  };
+
+  chrome.runtime.onMessage.addListener(
+    (
+      message: CaptureRequest,
+      _sender: chrome.runtime.MessageSender,
+      sendResponse: (response: CaptureResponse) => void,
+    ) => {
+      if (message.type === "LINKU_EVERYTIME_CAPTURE_PING") {
+        sendResponse({ success: true, ready: true });
+        return false;
+      }
+
+      if (message.type === "LINKU_EVERYTIME_LIST_SEMESTERS") {
+        sendResponse({
+          success: true,
+          semesters: readSemesterOptions(),
+          currentSemester: readSemester(),
+        });
+        return false;
+      }
+
+      if (message.type === "LINKU_EVERYTIME_CAPTURE_CURRENT") {
+        waitForRenderedTimetable(message.data.semester).then((timetable) =>
+          sendResponse({ success: true, timetable }),
+        );
+        return true;
+      }
+
+      if (message.type === "LINKU_EVERYTIME_FETCH_SEMESTERS") {
+        fetchSemestersFromApi(message.data.semesters).then(sendResponse);
+        return true;
+      }
+
+      return false;
+    },
+  );
+}

--- a/src/content/everytime-timetable.ts
+++ b/src/content/everytime-timetable.ts
@@ -1,7 +1,6 @@
 import type {
   EverytimeCourse,
   EverytimeSemesterMetadata,
-  EverytimeSemesterTerm,
   EverytimeSubject,
   EverytimeTableMetadata,
   EverytimeTimetable,
@@ -11,6 +10,13 @@ import {
   getStableEverytimeSubjectColor,
   isEverytimeSubjectColor,
 } from "@/utils/everytimeTimetableColor";
+import {
+  EVERYTIME_SEMESTER_PATTERN,
+  formatEverytimeSemester,
+  isEverytimeSemesterTerm,
+  parseEverytimeSemester,
+} from "@/utils/everytimeSemester";
+import { isPrimaryEverytimeTable } from "@/utils/everytimeTimetableParsing";
 
 type CaptureRequest =
   | { type: "LINKU_EVERYTIME_CAPTURE_PING" }
@@ -37,11 +43,12 @@ const EVERYTIME_TABLE_LIST_URL = `${EVERYTIME_API_BASE_URL}/table/list/semester`
 const EVERYTIME_TABLE_DETAIL_URL = `${EVERYTIME_API_BASE_URL}/table`;
 const EVERYTIME_SELECT_SELECTOR = "#semesters";
 const EVERYTIME_TIMETABLE_SELECTOR = "#container.timetable";
-const EVERYTIME_SEMESTER_PATTERN = /^(20\d{2})년\s*(1|2|여름|겨울)학기$/;
 const SEMESTER_FETCH_CONCURRENCY = 4;
 const EVERYTIME_TIME_UNIT_PX = 25 / 6;
 const EVERYTIME_WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"];
 const TIMETABLE_RENDER_TIMEOUT_MS = 5_000;
+const EVERYTIME_API_TIMEOUT_MS = 10_000;
+const SEMESTER_METADATA_CACHE_TTL_MS = 5 * 60 * 1_000;
 
 const linkuWindow = window as Window & {
   __LINKU_EVERYTIME_CAPTURE_INSTALLED__?: boolean;
@@ -49,32 +56,15 @@ const linkuWindow = window as Window & {
 
 if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
   linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__ = true;
+  let semesterMetadataCache:
+    | {
+        expiresAt: number;
+        value: Map<string, EverytimeSemesterMetadata>;
+      }
+    | undefined;
 
   const exactText = (element: Element | null): string =>
     element?.textContent?.replace(/\s+/g, " ").trim() ?? "";
-
-  const isEverytimeSemesterTerm = (
-    value?: string,
-  ): value is EverytimeSemesterTerm =>
-    value === "1" || value === "여름" || value === "2" || value === "겨울";
-
-  const formatEverytimeSemester = (
-    year: number,
-    term: EverytimeSemesterTerm,
-  ): string => `${year}년 ${term}학기`;
-
-  const parseEverytimeSemester = (
-    semester: string,
-  ): { year: number; term: EverytimeSemesterTerm } | null => {
-    const match = semester.match(EVERYTIME_SEMESTER_PATTERN);
-    if (!match) {
-      return null;
-    }
-
-    const year = Number.parseInt(match[1], 10);
-    const term = match[2];
-    return isEverytimeSemesterTerm(term) ? { year, term } : null;
-  };
 
   const findTimetableRoot = (documentRoot: Document = document): HTMLElement | null =>
     documentRoot.querySelector<HTMLElement>(EVERYTIME_TIMETABLE_SELECTOR);
@@ -183,6 +173,10 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
     const subjects: EverytimeSubject[] = [];
 
     cells.forEach((cell, dayIndex) => {
+      if (dayIndex >= weekdays.length) {
+        return;
+      }
+
       const subjectElements = Array.from(
         cell.querySelectorAll(":scope > div.cols > div.subject"),
       );
@@ -203,6 +197,8 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
         const place = professor
           ? rawDetail.slice(professor.length).trim()
           : rawDetail;
+        const startTime = Math.round(top / EVERYTIME_TIME_UNIT_PX);
+        const endTime = Math.round((top + height) / EVERYTIME_TIME_UNIT_PX);
 
         subjects.push({
           id: `${expectedSemester}:${dayIndex}:${top}:${subjectIndex}`,
@@ -212,13 +208,16 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
           place: place || undefined,
           detail: [professor, place].filter(Boolean).join(" · ") || undefined,
           color: getColorClass(subject),
+          startTime,
+          endTime,
           top,
           height,
         });
       });
     });
 
-    const hourGridCount = root.querySelectorAll("table.tablebody div.grids > div.grid").length;
+    const firstGrid = bodyTable.querySelector("td div.grids");
+    const hourGridCount = firstGrid?.querySelectorAll(":scope > div.grid").length ?? 0;
     return {
       semester: readSemester(documentRoot) ?? expectedSemester,
       weekdays,
@@ -266,28 +265,50 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
     url: string,
     body: URLSearchParams,
   ): Promise<Document> => {
-    const response = await fetch(url, {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        Accept: "application/xml, text/xml, */*; q=0.01",
-        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-      },
-      body: body.toString(),
-    });
-    if (!response.ok) {
-      throw new Error("에브리타임 시간표 API를 불러오지 못했습니다.");
-    }
-
-    const documentRoot = new DOMParser().parseFromString(
-      await response.text(),
-      "application/xml",
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(
+      () => controller.abort(),
+      EVERYTIME_API_TIMEOUT_MS,
     );
-    if (documentRoot.querySelector("parsererror")) {
-      throw new Error("에브리타임 시간표 응답을 해석하지 못했습니다.");
-    }
 
-    return documentRoot;
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          Accept: "application/xml, text/xml, */*; q=0.01",
+          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+        body: body.toString(),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error("에브리타임 시간표 API를 불러오지 못했습니다.");
+      }
+
+      const documentRoot = new DOMParser().parseFromString(
+        await response.text(),
+        "application/xml",
+      );
+      if (
+        documentRoot.querySelector("parsererror") ||
+        documentRoot.querySelector("response > error")
+      ) {
+        throw new Error("에브리타임 시간표 응답을 해석하지 못했습니다.");
+      }
+
+      return documentRoot;
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw Object.assign(
+          new Error("에브리타임 시간표 요청 시간이 초과되었습니다."),
+          { cause: error },
+        );
+      }
+      throw error;
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
   };
 
   const parseSemesterMetadataList = (
@@ -323,6 +344,28 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
     });
 
     return metadataBySemester;
+  };
+
+  const getSemesterMetadataByLabel = async (): Promise<
+    Map<string, EverytimeSemesterMetadata>
+  > => {
+    if (
+      semesterMetadataCache &&
+      semesterMetadataCache.expiresAt > Date.now()
+    ) {
+      return semesterMetadataCache.value;
+    }
+
+    const documentRoot = await fetchEverytimeXml(
+      EVERYTIME_SEMESTER_LIST_URL,
+      new URLSearchParams(),
+    );
+    const value = parseSemesterMetadataList(documentRoot);
+    semesterMetadataCache = {
+      expiresAt: Date.now() + SEMESTER_METADATA_CACHE_TTL_MS,
+      value,
+    };
+    return value;
   };
 
   const parseTableMetadata = (
@@ -478,7 +521,12 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
     );
     const tables = Array.from(listDocument.querySelectorAll("response > table"));
     const selectedTable =
-      tables.find((table) => table.getAttribute("is_primary") === "1") ??
+      tables.find((table) =>
+        isPrimaryEverytimeTable(
+          table.getAttribute("primary"),
+          table.getAttribute("is_primary"),
+        ),
+      ) ??
       tables[0];
     if (!selectedTable) {
       return null;
@@ -514,13 +562,7 @@ if (!linkuWindow.__LINKU_EVERYTIME_CAPTURE_INSTALLED__) {
     let nextIndex = 0;
 
     try {
-      const semesterMetadataDocument = await fetchEverytimeXml(
-        EVERYTIME_SEMESTER_LIST_URL,
-        new URLSearchParams(),
-      );
-      const semesterMetadataByLabel = parseSemesterMetadataList(
-        semesterMetadataDocument,
-      );
+      const semesterMetadataByLabel = await getSemesterMetadataByLabel();
       const workers = Array.from(
         {
           length: Math.min(

--- a/src/hooks/useBlobObjectUrl.ts
+++ b/src/hooks/useBlobObjectUrl.ts
@@ -1,19 +1,19 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 
 export function useBlobObjectUrl(blob: Blob | null | undefined): string | null {
-  const objectUrl = useMemo(
-    () => (blob ? URL.createObjectURL(blob) : null),
-    [blob],
-  );
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
 
-  useEffect(
-    () => () => {
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    },
-    [objectUrl],
-  );
+  useEffect(() => {
+    if (!blob) {
+      setObjectUrl(null);
+      return;
+    }
+
+    const nextObjectUrl = URL.createObjectURL(blob);
+    setObjectUrl(nextObjectUrl);
+
+    return () => URL.revokeObjectURL(nextObjectUrl);
+  }, [blob]);
 
   return objectUrl;
 }

--- a/src/hooks/useBlobObjectUrl.ts
+++ b/src/hooks/useBlobObjectUrl.ts
@@ -1,0 +1,19 @@
+import { useEffect, useMemo } from "react";
+
+export function useBlobObjectUrl(blob: Blob | null | undefined): string | null {
+  const objectUrl = useMemo(
+    () => (blob ? URL.createObjectURL(blob) : null),
+    [blob],
+  );
+
+  useEffect(
+    () => () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    },
+    [objectUrl],
+  );
+
+  return objectUrl;
+}

--- a/src/hooks/useTimetable.ts
+++ b/src/hooks/useTimetable.ts
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  TIMETABLE_STORAGE_KEYS,
+  type ResolvedTimetableAsset,
+  type TimetableAssetMeta,
+  type TimetableImportMode,
+} from "@/types/timetable";
+import { importTimetableFromEverytime } from "@/utils/timetableImport";
+import {
+  deleteActiveTimetable,
+  getActiveTimetable,
+  getTimetableAssets,
+  saveTimetableAsset,
+  setActiveTimetable,
+} from "@/utils/timetableStorage";
+import { getErrorLogDetails, warnLog } from "@/utils/logger";
+import { readTimetablePng } from "@/components/Tabs/TimeTable/timetableImage";
+
+export type TimetableBusyState =
+  | "loading"
+  | "uploading"
+  | "importing"
+  | "deleting"
+  | null;
+
+export function useTimetable() {
+  const [asset, setAsset] = useState<ResolvedTimetableAsset | null>(null);
+  const [assets, setAssets] = useState<TimetableAssetMeta[]>([]);
+  const [busy, setBusy] = useState<TimetableBusyState>("loading");
+
+  const loadTimetable = useCallback(async () => {
+    try {
+      const [storedAsset, storedAssets] = await Promise.all([
+        getActiveTimetable(),
+        getTimetableAssets(),
+      ]);
+      setAsset(storedAsset);
+      setAssets(storedAssets);
+    } catch (error) {
+      warnLog("[Timetable] Failed to load saved timetable", getErrorLogDetails(error));
+      toast.error("저장된 시간표를 불러오지 못했습니다.");
+    } finally {
+      setBusy((current) => (current === "loading" ? null : current));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTimetable();
+
+    if (
+      typeof chrome === "undefined" ||
+      !chrome.runtime?.id ||
+      !chrome.storage?.onChanged
+    ) {
+      return;
+    }
+
+    const handleStorageChange = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string,
+    ) => {
+      if (
+        areaName === "local" &&
+        (changes[TIMETABLE_STORAGE_KEYS.assetIndex] ||
+          changes[TIMETABLE_STORAGE_KEYS.everytimeOverrides])
+      ) {
+        void loadTimetable();
+      }
+    };
+
+    chrome.storage.onChanged.addListener(handleStorageChange);
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange);
+  }, [loadTimetable]);
+
+  const saveUploadedFile = useCallback(
+    async (file: File) => {
+      setBusy("uploading");
+
+      try {
+        const png = await readTimetablePng(file);
+        const result = await saveTimetableAsset(png.blob, {
+          source: "upload",
+          width: png.width,
+          height: png.height,
+        });
+
+        await loadTimetable();
+        toast.success(
+          result.changed
+            ? "시간표를 이 브라우저에 저장했어요."
+            : "이미 저장된 시간표와 같은 이미지예요.",
+        );
+      } catch (error) {
+        warnLog("[Timetable] PNG upload failed", getErrorLogDetails(error));
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "시간표 이미지를 저장하지 못했습니다.",
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [loadTimetable],
+  );
+
+  const importFromEverytime = useCallback(async (mode: TimetableImportMode) => {
+    setBusy("importing");
+
+    try {
+      const result = await importTimetableFromEverytime(mode);
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      await loadTimetable();
+      const periodLabel = mode === "latest" ? "최근 4학기" : "이전 4학기";
+      toast.success(
+        result.importedCount === 0
+          ? `${periodLabel}에 수업이 있는 시간표를 찾지 못했어요.`
+          : result.updatedCount > 0
+            ? `${periodLabel} ${result.importedCount}개 학기 시간표를 가져왔어요.`
+            : `${periodLabel} 시간표가 이미 최신 상태예요.`,
+      );
+    } catch (error) {
+      warnLog(
+        "[Timetable] Everytime import request failed",
+        getErrorLogDetails(error),
+      );
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "에브리타임 시간표를 가져오지 못했습니다.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }, [loadTimetable]);
+
+  const importLatestEverytime = useCallback(
+    () => importFromEverytime("latest"),
+    [importFromEverytime],
+  );
+
+  const importPreviousEverytimeSemesters = useCallback(
+    () => importFromEverytime("previous"),
+    [importFromEverytime],
+  );
+
+  const deleteTimetable = useCallback(async () => {
+    setBusy("deleting");
+
+    try {
+      await deleteActiveTimetable();
+      await loadTimetable();
+      toast.success("저장된 시간표를 삭제했어요.");
+      return true;
+    } catch (error) {
+      warnLog("[Timetable] Delete failed", getErrorLogDetails(error));
+      toast.error("시간표를 삭제하지 못했습니다.");
+      return false;
+    } finally {
+      setBusy(null);
+    }
+  }, [loadTimetable]);
+
+  const selectTimetable = useCallback(
+    async (id: string) => {
+      if (asset?.meta.id === id) {
+        return;
+      }
+
+      setBusy("loading");
+      try {
+        await setActiveTimetable(id);
+        await loadTimetable();
+      } catch (error) {
+        warnLog("[Timetable] Failed to select timetable", getErrorLogDetails(error));
+        toast.error("시간표를 전환하지 못했습니다.");
+      } finally {
+        setBusy(null);
+      }
+    },
+    [asset?.meta.id, loadTimetable],
+  );
+
+  return {
+    asset,
+    assets,
+    busy,
+    saveUploadedFile,
+    importLatestEverytime,
+    importPreviousEverytimeSemesters,
+    deleteTimetable,
+    selectTimetable,
+  };
+}

--- a/src/hooks/useTimetable.ts
+++ b/src/hooks/useTimetable.ts
@@ -15,7 +15,7 @@ import {
   setActiveTimetable,
 } from "@/utils/timetableStorage";
 import { getErrorLogDetails, warnLog } from "@/utils/logger";
-import { readTimetablePng } from "@/components/Tabs/TimeTable/timetableImage";
+import { readTimetableImage } from "@/components/Tabs/TimeTable/timetableImage";
 
 export type TimetableBusyState =
   | "loading"
@@ -78,11 +78,11 @@ export function useTimetable() {
       setBusy("uploading");
 
       try {
-        const png = await readTimetablePng(file);
-        const result = await saveTimetableAsset(png.blob, {
+        const image = await readTimetableImage(file);
+        const result = await saveTimetableAsset(image.blob, {
           source: "upload",
-          width: png.width,
-          height: png.height,
+          width: image.width,
+          height: image.height,
         });
 
         await loadTimetable();
@@ -92,7 +92,7 @@ export function useTimetable() {
             : "이미 저장된 시간표와 같은 이미지예요.",
         );
       } catch (error) {
-        warnLog("[Timetable] PNG upload failed", getErrorLogDetails(error));
+        warnLog("[Timetable] Image upload failed", getErrorLogDetails(error));
         toast.error(
           error instanceof Error
             ? error.message

--- a/src/types/timetable.ts
+++ b/src/types/timetable.ts
@@ -9,6 +9,23 @@ export const TIMETABLE_STORAGE_KEYS = {
 export type TimetableSource = "upload" | "everytime";
 export type TimetableSyncStatus = "local" | "pending" | "synced" | "error";
 
+export const TIMETABLE_IMAGE_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+  "image/avif",
+] as const;
+
+export type TimetableImageMimeType =
+  (typeof TIMETABLE_IMAGE_MIME_TYPES)[number];
+
+export function isTimetableImageMimeType(
+  value: string,
+): value is TimetableImageMimeType {
+  return (TIMETABLE_IMAGE_MIME_TYPES as readonly string[]).includes(value);
+}
+
 export type EverytimeSemesterTerm = "1" | "여름" | "2" | "겨울";
 
 export interface EverytimeSemesterMetadata {
@@ -149,7 +166,7 @@ interface TimetableMetaBase {
 
 export interface UploadedTimetableMeta extends TimetableMetaBase {
   source: "upload";
-  mimeType: "image/png";
+  mimeType: TimetableImageMimeType;
   width: number;
   height: number;
   byteSize: number;

--- a/src/types/timetable.ts
+++ b/src/types/timetable.ts
@@ -1,0 +1,225 @@
+export const TIMETABLE_STORAGE_KEYS = {
+  assetIndex: "timetableAssetIndex",
+  legacyMeta: "timetableAssetMeta",
+  everytimeImportedSemesters: "timetableEverytimeImportedSemesters",
+  everytimeOverrides: "timetableEverytimeOverrides",
+  pendingImport: "timetablePendingEverytimeImport",
+} as const;
+
+export type TimetableSource = "upload" | "everytime";
+export type TimetableSyncStatus = "local" | "pending" | "synced" | "error";
+
+export type EverytimeSemesterTerm = "1" | "여름" | "2" | "겨울";
+
+export interface EverytimeSemesterMetadata {
+  year: number;
+  term: EverytimeSemesterTerm;
+  startDate?: string;
+  endDate?: string;
+  isFormal?: boolean;
+  isSupported?: boolean;
+  hasSyllabus?: boolean;
+  hasSubjectDatabase?: boolean;
+  subjectDatabaseUpdatedAt?: string;
+}
+
+export interface EverytimeTableMetadata {
+  id?: string;
+  name?: string;
+  year?: number;
+  term?: EverytimeSemesterTerm;
+  isDeleted?: boolean;
+  isPrivate?: boolean;
+  isPrimary?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface EverytimeCourseMeeting {
+  dayIndex: number;
+  startTime: number;
+  endTime: number;
+  place?: string;
+}
+
+export interface EverytimeCourse {
+  id: string;
+  internalId?: string;
+  title: string;
+  professor?: string;
+  timeText?: string;
+  defaultPlace?: string;
+  credit?: number;
+  isClosed?: boolean;
+  meetings: EverytimeCourseMeeting[];
+}
+
+export interface EverytimeSubject {
+  id: string;
+  subjectId?: string;
+  internalId?: string;
+  dayIndex: number;
+  title: string;
+  professor?: string;
+  place?: string;
+  defaultPlace?: string;
+  timeText?: string;
+  credit?: number;
+  isClosed?: boolean;
+  startTime?: number;
+  endTime?: number;
+  detail?: string;
+  color: string;
+  top: number;
+  height: number;
+}
+
+export interface EverytimeTimetable {
+  semester: string;
+  semesterMetadata?: EverytimeSemesterMetadata;
+  tableMetadata?: EverytimeTableMetadata;
+  courses?: EverytimeCourse[];
+  weekdays: string[];
+  slotCount: number;
+  subjects: EverytimeSubject[];
+}
+
+export type EverytimeCourseOverride = Partial<
+  Pick<
+    EverytimeCourse,
+    | "title"
+    | "professor"
+    | "timeText"
+    | "defaultPlace"
+    | "credit"
+    | "isClosed"
+  >
+>;
+
+export type EverytimeSubjectOverride = Partial<
+  Pick<
+    EverytimeSubject,
+    | "dayIndex"
+    | "title"
+    | "professor"
+    | "place"
+    | "defaultPlace"
+    | "timeText"
+    | "credit"
+    | "isClosed"
+    | "startTime"
+    | "endTime"
+    | "detail"
+    | "color"
+    | "top"
+    | "height"
+  >
+>;
+
+export interface EverytimeTimetableOverrideInput {
+  courseOverrides?: Record<string, EverytimeCourseOverride>;
+  subjectOverrides?: Record<string, EverytimeSubjectOverride>;
+  hiddenCourseIds?: string[];
+  hiddenSubjectIds?: string[];
+  addedCourses?: EverytimeCourse[];
+  addedSubjects?: EverytimeSubject[];
+}
+
+export interface EverytimeTimetableOverride
+  extends Required<EverytimeTimetableOverrideInput> {
+  schemaVersion: 1;
+  assetId: string;
+  updatedAt: string;
+}
+
+export interface EverytimeTimetableOverrideIndex {
+  schemaVersion: 1;
+  overrides: Record<string, EverytimeTimetableOverride>;
+}
+
+interface TimetableMetaBase {
+  schemaVersion: 3;
+  id: string;
+  source: TimetableSource;
+  semester?: string;
+  syncStatus: TimetableSyncStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UploadedTimetableMeta extends TimetableMetaBase {
+  source: "upload";
+  mimeType: "image/png";
+  width: number;
+  height: number;
+  byteSize: number;
+  checksum: string;
+}
+
+export interface EverytimeTimetableMeta extends TimetableMetaBase {
+  source: "everytime";
+  snapshot: EverytimeTimetable;
+  snapshotChecksum: string;
+}
+
+export type TimetableAssetMeta =
+  | UploadedTimetableMeta
+  | EverytimeTimetableMeta;
+
+export type ResolvedTimetableAsset =
+  | {
+      kind: "upload";
+      meta: UploadedTimetableMeta;
+      blob: Blob;
+    }
+  | {
+      kind: "everytime";
+      meta: EverytimeTimetableMeta;
+      override: EverytimeTimetableOverride | null;
+      timetable: EverytimeTimetable;
+    };
+
+export interface SaveTimetableInput {
+  id?: string;
+  source: "upload";
+  width: number;
+  height: number;
+}
+
+export interface TimetableAssetIndex {
+  schemaVersion: 3;
+  activeAssetId: string | null;
+  assets: TimetableAssetMeta[];
+}
+
+export interface PendingEverytimeImport {
+  tabId: number;
+  createdByLinku: boolean;
+  requestedAt: string;
+  mode: TimetableImportMode;
+}
+
+export type TimetableImportMode = "latest" | "previous";
+
+export type TimetableImportErrorCode =
+  | "LOGIN_REQUIRED"
+  | "NO_PREVIOUS_SEMESTERS"
+  | "TIMETABLE_NOT_FOUND"
+  | "CAPTURE_FAILED"
+  | "TAB_UNAVAILABLE"
+  | "UNKNOWN";
+
+export type TimetableImportResponse =
+  | {
+      success: true;
+      activeAssetId: string | null;
+      importedCount: number;
+      updatedCount: number;
+      skippedCount: number;
+    }
+  | {
+      success: false;
+      code: TimetableImportErrorCode;
+      error: string;
+      loginTabId?: number;
+    };

--- a/src/utils/everytimeSemester.ts
+++ b/src/utils/everytimeSemester.ts
@@ -1,6 +1,7 @@
 import type { EverytimeSemesterTerm } from "@/types/timetable";
 
-const EVERYTIME_SEMESTER_PATTERN = /^(20\d{2})년\s*(1|2|여름|겨울)학기$/;
+export const EVERYTIME_SEMESTER_PATTERN =
+  /^(20\d{2})년\s*(1|2|여름|겨울)학기$/;
 
 const EVERYTIME_SEMESTER_TERM_ORDER: Record<EverytimeSemesterTerm, number> = {
   "1": 0,
@@ -20,7 +21,7 @@ export interface EverytimeSemesterPeriod {
   sortKey: number;
 }
 
-function isEverytimeSemesterTerm(
+export function isEverytimeSemesterTerm(
   value?: string,
 ): value is EverytimeSemesterTerm {
   return (
@@ -37,6 +38,31 @@ export function getEverytimeSemesterSortKey(
     year * EVERYTIME_SEMESTER_TERM_COUNT +
     EVERYTIME_SEMESTER_TERM_ORDER[term]
   );
+}
+
+export function formatEverytimeSemester(
+  year: number,
+  term: EverytimeSemesterTerm,
+): string {
+  return `${year}년 ${term}학기`;
+}
+
+export function getLatestEverytimeSemesterAnchor(
+  now: Date,
+): Pick<EverytimeSemesterPeriod, "year" | "term" | "sortKey"> {
+  const month = now.getMonth();
+  const isWinterBreak = month === 11;
+  const year = isWinterBreak ? now.getFullYear() + 1 : now.getFullYear();
+  const term = month < 5 || isWinterBreak ? "1" : "2";
+
+  return {
+    year,
+    term,
+    // 1~5월에는 해당 연도 1학기, 6~11월에는 다음 정규학기인 2학기를
+    // 기준으로 삼는다. 12월 겨울방학에는 다음 연도 1학기를 기준으로 삼아
+    // 현재 겨울학기도 최근 학기 후보에 포함한다.
+    sortKey: getEverytimeSemesterSortKey(year, term),
+  };
 }
 
 export function parseEverytimeSemester(

--- a/src/utils/everytimeSemester.ts
+++ b/src/utils/everytimeSemester.ts
@@ -1,0 +1,62 @@
+import type { EverytimeSemesterTerm } from "@/types/timetable";
+
+const EVERYTIME_SEMESTER_PATTERN = /^(20\d{2})년\s*(1|2|여름|겨울)학기$/;
+
+const EVERYTIME_SEMESTER_TERM_ORDER: Record<EverytimeSemesterTerm, number> = {
+  "1": 0,
+  여름: 1,
+  "2": 2,
+  겨울: 3,
+};
+
+const EVERYTIME_SEMESTER_TERM_COUNT = Object.keys(
+  EVERYTIME_SEMESTER_TERM_ORDER,
+).length;
+
+export interface EverytimeSemesterPeriod {
+  label: string;
+  year: number;
+  term: EverytimeSemesterTerm;
+  sortKey: number;
+}
+
+function isEverytimeSemesterTerm(
+  value?: string,
+): value is EverytimeSemesterTerm {
+  return (
+    value !== undefined &&
+    Object.prototype.hasOwnProperty.call(EVERYTIME_SEMESTER_TERM_ORDER, value)
+  );
+}
+
+export function getEverytimeSemesterSortKey(
+  year: number,
+  term: EverytimeSemesterTerm,
+): number {
+  return (
+    year * EVERYTIME_SEMESTER_TERM_COUNT +
+    EVERYTIME_SEMESTER_TERM_ORDER[term]
+  );
+}
+
+export function parseEverytimeSemester(
+  semester: string,
+): EverytimeSemesterPeriod | null {
+  const match = semester.match(EVERYTIME_SEMESTER_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number.parseInt(match[1], 10);
+  const term = match[2];
+  if (!isEverytimeSemesterTerm(term)) {
+    return null;
+  }
+
+  return {
+    label: semester,
+    year,
+    term,
+    sortKey: getEverytimeSemesterSortKey(year, term),
+  };
+}

--- a/src/utils/everytimeTimetable.ts
+++ b/src/utils/everytimeTimetable.ts
@@ -31,12 +31,6 @@ function mergeCourse(
   };
 }
 
-function getCourseFieldsForSubject(
-  override?: EverytimeCourseOverride,
-): EverytimeSubjectOverride | undefined {
-  return override;
-}
-
 function mergeSubject(
   subject: EverytimeSubject,
   courseOverride?: EverytimeCourseOverride,
@@ -46,10 +40,9 @@ function mergeSubject(
     return subject;
   }
 
-  const courseFields = getCourseFieldsForSubject(courseOverride);
   const mergedSubject: EverytimeSubject = {
     ...subject,
-    ...courseFields,
+    ...courseOverride,
     ...subjectOverride,
     id: subject.id,
     subjectId: subject.subjectId,
@@ -57,7 +50,7 @@ function mergeSubject(
   };
   const detailFieldsChanged = DETAIL_FIELDS.some(
     (field) =>
-      (courseFields && hasOwnProperty(courseFields, field)) ||
+      (courseOverride && hasOwnProperty(courseOverride, field)) ||
       (subjectOverride && hasOwnProperty(subjectOverride, field)),
   );
   const detailWasOverridden =

--- a/src/utils/everytimeTimetable.ts
+++ b/src/utils/everytimeTimetable.ts
@@ -1,0 +1,172 @@
+import type {
+  EverytimeCourse,
+  EverytimeCourseOverride,
+  EverytimeSubject,
+  EverytimeSubjectOverride,
+  EverytimeTimetable,
+  EverytimeTimetableOverride,
+  EverytimeTimetableOverrideInput,
+} from "@/types/timetable";
+
+const DETAIL_FIELDS = ["professor", "place"] as const;
+
+function hasOwnProperty<T extends object>(object: T, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function mergeCourse(
+  course: EverytimeCourse,
+  override?: EverytimeCourseOverride,
+): EverytimeCourse {
+  if (!override) {
+    return course;
+  }
+
+  return {
+    ...course,
+    ...override,
+    id: course.id,
+    internalId: course.internalId,
+    meetings: course.meetings,
+  };
+}
+
+function getCourseFieldsForSubject(
+  override?: EverytimeCourseOverride,
+): EverytimeSubjectOverride | undefined {
+  return override;
+}
+
+function mergeSubject(
+  subject: EverytimeSubject,
+  courseOverride?: EverytimeCourseOverride,
+  subjectOverride?: EverytimeSubjectOverride,
+): EverytimeSubject {
+  if (!courseOverride && !subjectOverride) {
+    return subject;
+  }
+
+  const courseFields = getCourseFieldsForSubject(courseOverride);
+  const mergedSubject: EverytimeSubject = {
+    ...subject,
+    ...courseFields,
+    ...subjectOverride,
+    id: subject.id,
+    subjectId: subject.subjectId,
+    internalId: subject.internalId,
+  };
+  const detailFieldsChanged = DETAIL_FIELDS.some(
+    (field) =>
+      (courseFields && hasOwnProperty(courseFields, field)) ||
+      (subjectOverride && hasOwnProperty(subjectOverride, field)),
+  );
+  const detailWasOverridden =
+    subjectOverride && hasOwnProperty(subjectOverride, "detail");
+
+  if (detailFieldsChanged && !detailWasOverridden) {
+    mergedSubject.detail =
+      [mergedSubject.professor, mergedSubject.place]
+        .filter(Boolean)
+        .join(" · ") || undefined;
+  }
+
+  return mergedSubject;
+}
+
+function appendUniqueById<T extends { id: string }>(
+  source: T[],
+  additions: T[],
+): T[] {
+  const sourceIds = new Set(source.map((item) => item.id));
+  return [
+    ...source,
+    ...additions.filter((item) => !sourceIds.has(item.id)),
+  ];
+}
+
+export function createEverytimeTimetableOverride(
+  assetId: string,
+  input: EverytimeTimetableOverrideInput,
+  updatedAt = new Date().toISOString(),
+): EverytimeTimetableOverride {
+  return {
+    schemaVersion: 1,
+    assetId,
+    courseOverrides: input.courseOverrides ?? {},
+    subjectOverrides: input.subjectOverrides ?? {},
+    hiddenCourseIds: [...new Set(input.hiddenCourseIds ?? [])],
+    hiddenSubjectIds: [...new Set(input.hiddenSubjectIds ?? [])],
+    addedCourses: input.addedCourses ?? [],
+    addedSubjects: input.addedSubjects ?? [],
+    updatedAt,
+  };
+}
+
+export function isEverytimeTimetableOverrideEmpty(
+  override: EverytimeTimetableOverride,
+): boolean {
+  return (
+    Object.keys(override.courseOverrides).length === 0 &&
+    Object.keys(override.subjectOverrides).length === 0 &&
+    override.hiddenCourseIds.length === 0 &&
+    override.hiddenSubjectIds.length === 0 &&
+    override.addedCourses.length === 0 &&
+    override.addedSubjects.length === 0
+  );
+}
+
+export function mergeEverytimeTimetable(
+  snapshot: EverytimeTimetable,
+  override?: EverytimeTimetableOverride,
+): EverytimeTimetable {
+  if (!override || isEverytimeTimetableOverrideEmpty(override)) {
+    return snapshot;
+  }
+
+  const hiddenCourseIds = new Set(override.hiddenCourseIds);
+  const hiddenSubjectIds = new Set(override.hiddenSubjectIds);
+  const snapshotCourses = (snapshot.courses ?? [])
+    .filter((course) => !hiddenCourseIds.has(course.id))
+    .map((course) => mergeCourse(course, override.courseOverrides[course.id]));
+  const addedCourses = override.addedCourses
+    .filter((course) => !hiddenCourseIds.has(course.id))
+    .map((course) => mergeCourse(course, override.courseOverrides[course.id]));
+  const courses = appendUniqueById(snapshotCourses, addedCourses);
+  const snapshotSubjects = snapshot.subjects
+    .filter(
+      (subject) =>
+        !hiddenSubjectIds.has(subject.id) &&
+        (!subject.subjectId || !hiddenCourseIds.has(subject.subjectId)),
+    )
+    .map((subject) =>
+      mergeSubject(
+        subject,
+        subject.subjectId
+          ? override.courseOverrides[subject.subjectId]
+          : undefined,
+        override.subjectOverrides[subject.id],
+      ),
+    );
+  const addedSubjects = override.addedSubjects
+    .filter(
+      (subject) =>
+        !hiddenSubjectIds.has(subject.id) &&
+        (!subject.subjectId || !hiddenCourseIds.has(subject.subjectId)),
+    )
+    .map((subject) =>
+      mergeSubject(
+        subject,
+        subject.subjectId
+          ? override.courseOverrides[subject.subjectId]
+          : undefined,
+        override.subjectOverrides[subject.id],
+      ),
+    );
+
+  return {
+    ...snapshot,
+    courses:
+      snapshot.courses !== undefined || courses.length > 0 ? courses : undefined,
+    subjects: appendUniqueById(snapshotSubjects, addedSubjects),
+  };
+}

--- a/src/utils/everytimeTimetableColor.ts
+++ b/src/utils/everytimeTimetableColor.ts
@@ -1,0 +1,43 @@
+const EVERYTIME_SUBJECT_COLORS = [
+  "color1",
+  "color2",
+  "color3",
+  "color4",
+  "color5",
+  "color6",
+  "color7",
+  "color8",
+  "color9",
+  "color10",
+  "color11",
+  "color12",
+  "color13",
+  "color14",
+  "color15",
+  "color16",
+] as const;
+
+export type EverytimeSubjectColor = (typeof EVERYTIME_SUBJECT_COLORS)[number];
+
+export const DEFAULT_EVERYTIME_SUBJECT_COLOR: EverytimeSubjectColor = "color1";
+
+export function isEverytimeSubjectColor(
+  value: string,
+): value is EverytimeSubjectColor {
+  return (EVERYTIME_SUBJECT_COLORS as readonly string[]).includes(value);
+}
+
+export function getStableEverytimeSubjectColor(
+  courseId: string,
+): EverytimeSubjectColor {
+  const hash = Array.from(courseId).reduce(
+    (value, character, index) =>
+      value + (character.codePointAt(0) ?? 0) * (index + 1),
+    0,
+  );
+
+  return (
+    EVERYTIME_SUBJECT_COLORS[hash % EVERYTIME_SUBJECT_COLORS.length] ??
+    DEFAULT_EVERYTIME_SUBJECT_COLOR
+  );
+}

--- a/src/utils/everytimeTimetableParsing.ts
+++ b/src/utils/everytimeTimetableParsing.ts
@@ -1,0 +1,6 @@
+export function isPrimaryEverytimeTable(
+  primary?: string | null,
+  isPrimary?: string | null,
+): boolean {
+  return primary?.trim() === "1" || isPrimary?.trim() === "1";
+}

--- a/src/utils/timetableImport.ts
+++ b/src/utils/timetableImport.ts
@@ -1,0 +1,24 @@
+import {
+  BackgroundMessageType,
+  type TimetableImportResponse,
+} from "@/background/types";
+import type { TimetableImportMode } from "@/types/timetable";
+
+export async function importTimetableFromEverytime(
+  mode: TimetableImportMode = "latest",
+): Promise<TimetableImportResponse> {
+  if (
+    typeof chrome === "undefined" ||
+    !chrome.runtime?.id ||
+    !chrome.runtime.sendMessage
+  ) {
+    throw new Error(
+      "에브리타임 연동은 빌드된 Chrome 확장 프로그램에서 확인할 수 있습니다.",
+    );
+  }
+
+  return chrome.runtime.sendMessage({
+    type: BackgroundMessageType.TIMETABLE_IMPORT,
+    data: { mode },
+  });
+}

--- a/src/utils/timetableImport.ts
+++ b/src/utils/timetableImport.ts
@@ -4,6 +4,43 @@ import {
 } from "@/background/types";
 import type { TimetableImportMode } from "@/types/timetable";
 
+const TIMETABLE_IMPORT_ERROR_CODES = new Set([
+  "LOGIN_REQUIRED",
+  "NO_PREVIOUS_SEMESTERS",
+  "TIMETABLE_NOT_FOUND",
+  "CAPTURE_FAILED",
+  "TAB_UNAVAILABLE",
+  "UNKNOWN",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTimetableImportResponse(
+  value: unknown,
+): value is TimetableImportResponse {
+  if (!isRecord(value) || typeof value.success !== "boolean") {
+    return false;
+  }
+
+  if (!value.success) {
+    return (
+      typeof value.error === "string" &&
+      typeof value.code === "string" &&
+      TIMETABLE_IMPORT_ERROR_CODES.has(value.code)
+    );
+  }
+
+  return (
+    (typeof value.activeAssetId === "string" ||
+      value.activeAssetId === null) &&
+    typeof value.importedCount === "number" &&
+    typeof value.updatedCount === "number" &&
+    typeof value.skippedCount === "number"
+  );
+}
+
 export async function importTimetableFromEverytime(
   mode: TimetableImportMode = "latest",
 ): Promise<TimetableImportResponse> {
@@ -17,8 +54,16 @@ export async function importTimetableFromEverytime(
     );
   }
 
-  return chrome.runtime.sendMessage({
+  const response: unknown = await chrome.runtime.sendMessage({
     type: BackgroundMessageType.TIMETABLE_IMPORT,
     data: { mode },
   });
+
+  if (!isTimetableImportResponse(response)) {
+    throw new Error(
+      "확장 프로그램에서 응답을 받지 못했습니다. 확장 프로그램을 새로고침한 뒤 다시 시도해주세요.",
+    );
+  }
+
+  return response;
 }

--- a/src/utils/timetableStorage.ts
+++ b/src/utils/timetableStorage.ts
@@ -1,0 +1,678 @@
+import type {
+  EverytimeTimetable,
+  EverytimeTimetableMeta,
+  EverytimeTimetableOverride,
+  EverytimeTimetableOverrideIndex,
+  EverytimeTimetableOverrideInput,
+  ResolvedTimetableAsset,
+  SaveTimetableInput,
+  TimetableAssetIndex,
+  TimetableAssetMeta,
+  UploadedTimetableMeta,
+} from "@/types/timetable";
+import { TIMETABLE_STORAGE_KEYS } from "@/types/timetable";
+import { getStorage, removeStorage, setStorage } from "@/utils/chrome";
+import {
+  createEverytimeTimetableOverride,
+  isEverytimeTimetableOverrideEmpty,
+  mergeEverytimeTimetable,
+} from "@/utils/everytimeTimetable";
+
+const DATABASE_NAME = "linku-timetable";
+const DATABASE_VERSION = 1;
+const ASSET_STORE_NAME = "assets";
+const UPLOADED_TIMETABLE_ASSET_ID = "uploaded";
+const EVERYTIME_TIMETABLE_ASSET_PREFIX = "everytime:";
+
+interface TimetableBlobRecord {
+  id: string;
+  blob: Blob;
+}
+
+interface LegacyTimetableAssetMeta {
+  id: string;
+  source: "upload" | "everytime-capture";
+  semester?: string;
+  mimeType: "image/png";
+  width: number;
+  height: number;
+  byteSize: number;
+  checksum: string;
+  syncStatus: "local" | "pending" | "synced" | "error";
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface LegacyTimetableAssetIndex {
+  schemaVersion: 1;
+  activeAssetId: string | null;
+  assets: LegacyTimetableAssetMeta[];
+}
+
+interface LegacyV2TimetableMetaBase {
+  schemaVersion: 2;
+  id: string;
+  source: "upload" | "everytime";
+  semester?: string;
+  syncStatus: "local" | "pending" | "synced" | "error";
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface LegacyV2UploadedTimetableMeta extends LegacyV2TimetableMetaBase {
+  source: "upload";
+  mimeType: "image/png";
+  width: number;
+  height: number;
+  byteSize: number;
+  checksum: string;
+}
+
+interface LegacyV2EverytimeTimetableMeta extends LegacyV2TimetableMetaBase {
+  source: "everytime";
+  timetable: EverytimeTimetable;
+  checksum: string;
+}
+
+type LegacyV2TimetableAssetMeta =
+  | LegacyV2UploadedTimetableMeta
+  | LegacyV2EverytimeTimetableMeta;
+
+interface LegacyV2TimetableAssetIndex {
+  schemaVersion: 2;
+  activeAssetId: string | null;
+  assets: LegacyV2TimetableAssetMeta[];
+}
+
+function hasExtensionStorage(): boolean {
+  return (
+    typeof chrome !== "undefined" &&
+    Boolean(chrome.runtime?.id) &&
+    Boolean(chrome.storage?.local)
+  );
+}
+
+async function getTimetableSetting<T>(key: string): Promise<T | undefined> {
+  if (hasExtensionStorage()) {
+    return getStorage<T>(key);
+  }
+
+  const value = localStorage.getItem(key);
+  return value ? (JSON.parse(value) as T) : undefined;
+}
+
+async function setTimetableSettings(
+  data: Record<string, unknown>,
+): Promise<void> {
+  if (hasExtensionStorage()) {
+    return setStorage(data);
+  }
+
+  Object.entries(data).forEach(([key, value]) => {
+    localStorage.setItem(key, JSON.stringify(value));
+  });
+}
+
+async function removeTimetableSetting(key: string): Promise<void> {
+  if (hasExtensionStorage()) {
+    return removeStorage(key);
+  }
+
+  localStorage.removeItem(key);
+}
+
+function isTimetableAssetIndex(value: unknown): value is TimetableAssetIndex {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 3 &&
+    "assets" in value &&
+    Array.isArray(value.assets)
+  );
+}
+
+function isLegacyV2TimetableAssetIndex(
+  value: unknown,
+): value is LegacyV2TimetableAssetIndex {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 2 &&
+    "assets" in value &&
+    Array.isArray(value.assets)
+  );
+}
+
+function isLegacyTimetableAssetIndex(
+  value: unknown,
+): value is LegacyTimetableAssetIndex {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 1 &&
+    "assets" in value &&
+    Array.isArray(value.assets)
+  );
+}
+
+function createEmptyAssetIndex(): TimetableAssetIndex {
+  return {
+    schemaVersion: 3,
+    activeAssetId: null,
+    assets: [],
+  };
+}
+
+function migrateLegacyAsset(
+  legacy: LegacyTimetableAssetMeta,
+): UploadedTimetableMeta {
+  return {
+    schemaVersion: 3,
+    id: legacy.id,
+    source: "upload",
+    mimeType: "image/png",
+    width: legacy.width,
+    height: legacy.height,
+    byteSize: legacy.byteSize,
+    checksum: legacy.checksum,
+    syncStatus: legacy.syncStatus,
+    createdAt: legacy.createdAt,
+    updatedAt: legacy.updatedAt,
+  };
+}
+
+function migrateV2Asset(
+  legacy: LegacyV2TimetableAssetMeta,
+): TimetableAssetMeta {
+  if (legacy.source === "everytime") {
+    return {
+      schemaVersion: 3,
+      id: legacy.id,
+      source: "everytime",
+      semester: legacy.semester,
+      snapshot: legacy.timetable,
+      snapshotChecksum: legacy.checksum,
+      syncStatus: legacy.syncStatus,
+      createdAt: legacy.createdAt,
+      updatedAt: legacy.updatedAt,
+    };
+  }
+
+  return {
+    ...legacy,
+    schemaVersion: 3,
+  };
+}
+
+async function getTimetableAssetIndex(): Promise<TimetableAssetIndex> {
+  const storedIndex = await getTimetableSetting<unknown>(
+    TIMETABLE_STORAGE_KEYS.assetIndex,
+  );
+  if (isTimetableAssetIndex(storedIndex)) {
+    return storedIndex;
+  }
+
+  if (isLegacyV2TimetableAssetIndex(storedIndex)) {
+    const migratedIndex: TimetableAssetIndex = {
+      schemaVersion: 3,
+      activeAssetId: storedIndex.activeAssetId,
+      assets: storedIndex.assets.map(migrateV2Asset),
+    };
+    await setTimetableAssetIndex(migratedIndex);
+    return migratedIndex;
+  }
+
+  const legacyIndex = isLegacyTimetableAssetIndex(storedIndex)
+    ? storedIndex
+    : undefined;
+  const legacyMeta = legacyIndex
+    ? undefined
+    : await getTimetableSetting<LegacyTimetableAssetMeta>(
+        TIMETABLE_STORAGE_KEYS.legacyMeta,
+      );
+  const legacyAssets = legacyIndex?.assets ?? (legacyMeta ? [legacyMeta] : []);
+
+  if (legacyAssets.length === 0) {
+    return createEmptyAssetIndex();
+  }
+
+  const migratedIndex: TimetableAssetIndex = {
+    schemaVersion: 3,
+    activeAssetId: legacyIndex?.activeAssetId ?? legacyMeta?.id ?? null,
+    assets: legacyAssets.map(migrateLegacyAsset),
+  };
+
+  await setTimetableSettings({
+    [TIMETABLE_STORAGE_KEYS.assetIndex]: migratedIndex,
+  });
+  await removeTimetableSetting(TIMETABLE_STORAGE_KEYS.legacyMeta);
+
+  return migratedIndex;
+}
+
+async function setTimetableAssetIndex(
+  index: TimetableAssetIndex,
+): Promise<void> {
+  await setTimetableSettings({
+    [TIMETABLE_STORAGE_KEYS.assetIndex]: index,
+  });
+}
+
+function createEmptyOverrideIndex(): EverytimeTimetableOverrideIndex {
+  return {
+    schemaVersion: 1,
+    overrides: {},
+  };
+}
+
+function isEverytimeTimetableOverrideIndex(
+  value: unknown,
+): value is EverytimeTimetableOverrideIndex {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "schemaVersion" in value &&
+    value.schemaVersion === 1 &&
+    "overrides" in value &&
+    typeof value.overrides === "object" &&
+    value.overrides !== null
+  );
+}
+
+async function getEverytimeTimetableOverrideIndex(): Promise<
+  EverytimeTimetableOverrideIndex
+> {
+  const storedIndex = await getTimetableSetting<unknown>(
+    TIMETABLE_STORAGE_KEYS.everytimeOverrides,
+  );
+  return isEverytimeTimetableOverrideIndex(storedIndex)
+    ? storedIndex
+    : createEmptyOverrideIndex();
+}
+
+async function setEverytimeTimetableOverrideIndex(
+  index: EverytimeTimetableOverrideIndex,
+): Promise<void> {
+  await setTimetableSettings({
+    [TIMETABLE_STORAGE_KEYS.everytimeOverrides]: index,
+  });
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(ASSET_STORE_NAME)) {
+        database.createObjectStore(ASSET_STORE_NAME, { keyPath: "id" });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("시간표 저장소를 열 수 없습니다."));
+  });
+}
+
+function runTransaction<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openDatabase().then(
+    (database) =>
+      new Promise<T>((resolve, reject) => {
+        const transaction = database.transaction(ASSET_STORE_NAME, mode);
+        const store = transaction.objectStore(ASSET_STORE_NAME);
+        const request = operation(store);
+        let result: T;
+
+        request.onsuccess = () => {
+          result = request.result;
+        };
+        request.onerror = () => {
+          database.close();
+          reject(request.error ?? new Error("시간표 저장에 실패했습니다."));
+        };
+        transaction.oncomplete = () => {
+          database.close();
+          resolve(result);
+        };
+        transaction.onerror = () => {
+          database.close();
+          reject(
+            transaction.error ?? new Error("시간표 저장에 실패했습니다."),
+          );
+        };
+      }),
+  );
+}
+
+async function calculateChecksum(value: Blob | string): Promise<string> {
+  const buffer =
+    typeof value === "string"
+      ? new TextEncoder().encode(value)
+      : await value.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", buffer);
+
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function getAssetId(input: SaveTimetableInput): string {
+  return input.id ?? UPLOADED_TIMETABLE_ASSET_ID;
+}
+
+function assertUniqueAddedIds(
+  label: string,
+  sourceIds: Set<string>,
+  addedIds: string[],
+): void {
+  const seenIds = new Set<string>();
+  const conflictingId = addedIds.find((id) => {
+    if (sourceIds.has(id) || seenIds.has(id)) {
+      return true;
+    }
+
+    seenIds.add(id);
+    return false;
+  });
+
+  if (conflictingId) {
+    throw new Error(`${label} ID가 원본 또는 다른 사용자 추가 항목과 겹칩니다.`);
+  }
+}
+
+function validateOverrideAdditions(
+  snapshot: EverytimeTimetable,
+  input: EverytimeTimetableOverrideInput,
+): void {
+  assertUniqueAddedIds(
+    "사용자 추가 과목",
+    new Set((snapshot.courses ?? []).map((course) => course.id)),
+    (input.addedCourses ?? []).map((course) => course.id),
+  );
+  assertUniqueAddedIds(
+    "사용자 추가 수업",
+    new Set(snapshot.subjects.map((subject) => subject.id)),
+    (input.addedSubjects ?? []).map((subject) => subject.id),
+  );
+}
+
+function replaceAsset(
+  index: TimetableAssetIndex,
+  asset: TimetableAssetMeta,
+  activate: boolean,
+): TimetableAssetIndex {
+  return {
+    schemaVersion: 3,
+    activeAssetId:
+      activate || !index.activeAssetId ? asset.id : index.activeAssetId,
+    assets: [asset, ...index.assets.filter((stored) => stored.id !== asset.id)],
+  };
+}
+
+export function getEverytimeTimetableAssetId(semester: string): string {
+  return `${EVERYTIME_TIMETABLE_ASSET_PREFIX}${semester}`;
+}
+
+export async function saveTimetableAsset(
+  blob: Blob,
+  input: SaveTimetableInput,
+): Promise<{ meta: UploadedTimetableMeta; changed: boolean }> {
+  if (blob.type !== "image/png") {
+    throw new Error("PNG 파일만 저장할 수 있습니다.");
+  }
+
+  const id = getAssetId(input);
+  const checksum = await calculateChecksum(blob);
+  const index = await getTimetableAssetIndex();
+  const previousMeta = index.assets.find(
+    (asset): asset is UploadedTimetableMeta =>
+      asset.id === id && asset.source === "upload",
+  );
+
+  if (previousMeta?.checksum === checksum) {
+    const existingRecord = await runTransaction<
+      TimetableBlobRecord | undefined
+    >("readonly", (store) => store.get(id));
+
+    if (existingRecord?.blob) {
+      if (index.activeAssetId !== id) {
+        await setTimetableAssetIndex(replaceAsset(index, previousMeta, true));
+      }
+      return { meta: previousMeta, changed: false };
+    }
+  }
+
+  const now = new Date().toISOString();
+  const meta: UploadedTimetableMeta = {
+    schemaVersion: 3,
+    id,
+    source: "upload",
+    mimeType: "image/png",
+    width: input.width,
+    height: input.height,
+    byteSize: blob.size,
+    checksum,
+    syncStatus: "local",
+    createdAt: previousMeta?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  await runTransaction<IDBValidKey>("readwrite", (store) =>
+    store.put({ id, blob } satisfies TimetableBlobRecord),
+  );
+
+  try {
+    await setTimetableAssetIndex(replaceAsset(index, meta, true));
+  } catch (error) {
+    await runTransaction<undefined>("readwrite", (store) => store.delete(id));
+    throw error;
+  }
+
+  return { meta, changed: true };
+}
+
+export async function saveEverytimeTimetable(
+  snapshot: EverytimeTimetable,
+): Promise<{ meta: EverytimeTimetableMeta; changed: boolean }> {
+  const id = getEverytimeTimetableAssetId(snapshot.semester);
+  const snapshotChecksum = await calculateChecksum(JSON.stringify(snapshot));
+  const index = await getTimetableAssetIndex();
+  const previousMeta = index.assets.find(
+    (asset): asset is EverytimeTimetableMeta =>
+      asset.id === id && asset.source === "everytime",
+  );
+
+  if (previousMeta?.snapshotChecksum === snapshotChecksum) {
+    return { meta: previousMeta, changed: false };
+  }
+
+  const now = new Date().toISOString();
+  const meta: EverytimeTimetableMeta = {
+    schemaVersion: 3,
+    id,
+    source: "everytime",
+    semester: snapshot.semester,
+    snapshot,
+    snapshotChecksum,
+    syncStatus: "local",
+    createdAt: previousMeta?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  await setTimetableAssetIndex(replaceAsset(index, meta, false));
+  return { meta, changed: true };
+}
+
+export async function getEverytimeTimetableOverride(
+  assetId: string,
+): Promise<EverytimeTimetableOverride | null> {
+  const index = await getEverytimeTimetableOverrideIndex();
+  return index.overrides[assetId] ?? null;
+}
+
+export async function saveEverytimeTimetableOverride(
+  assetId: string,
+  input: EverytimeTimetableOverrideInput,
+): Promise<EverytimeTimetableOverride | null> {
+  const assetIndex = await getTimetableAssetIndex();
+  const asset = assetIndex.assets.find((candidate) => candidate.id === assetId);
+  if (asset?.source !== "everytime") {
+    throw new Error("사용자 수정을 저장할 에브리타임 시간표를 찾지 못했습니다.");
+  }
+  validateOverrideAdditions(asset.snapshot, input);
+
+  const overrideIndex = await getEverytimeTimetableOverrideIndex();
+  const override = createEverytimeTimetableOverride(assetId, input);
+  const overrides = { ...overrideIndex.overrides };
+
+  if (isEverytimeTimetableOverrideEmpty(override)) {
+    delete overrides[assetId];
+  } else {
+    overrides[assetId] = override;
+  }
+
+  await setEverytimeTimetableOverrideIndex({
+    schemaVersion: 1,
+    overrides,
+  });
+  return overrides[assetId] ?? null;
+}
+
+export async function clearEverytimeTimetableOverride(
+  assetId: string,
+): Promise<void> {
+  const overrideIndex = await getEverytimeTimetableOverrideIndex();
+  if (!overrideIndex.overrides[assetId]) {
+    return;
+  }
+
+  const overrides = { ...overrideIndex.overrides };
+  delete overrides[assetId];
+  await setEverytimeTimetableOverrideIndex({
+    schemaVersion: 1,
+    overrides,
+  });
+}
+
+export async function getTimetableAssets(): Promise<TimetableAssetMeta[]> {
+  const index = await getTimetableAssetIndex();
+  return index.assets;
+}
+
+export async function getActiveTimetable(): Promise<
+  ResolvedTimetableAsset | null
+> {
+  const index = await getTimetableAssetIndex();
+  const meta = index.assets.find((asset) => asset.id === index.activeAssetId);
+  if (!meta) {
+    return null;
+  }
+
+  if (meta.source === "everytime") {
+    const override = await getEverytimeTimetableOverride(meta.id);
+    return {
+      kind: "everytime",
+      meta,
+      override,
+      timetable: mergeEverytimeTimetable(meta.snapshot, override ?? undefined),
+    };
+  }
+
+  const record = await runTransaction<TimetableBlobRecord | undefined>(
+    "readonly",
+    (store) => store.get(meta.id),
+  );
+
+  if (!record?.blob) {
+    const assets = index.assets.filter((asset) => asset.id !== meta.id);
+    await setTimetableAssetIndex({
+      schemaVersion: 3,
+      activeAssetId: assets[0]?.id ?? null,
+      assets,
+    });
+    return null;
+  }
+
+  return { kind: "upload", meta, blob: record.blob };
+}
+
+export async function setActiveTimetable(id: string): Promise<void> {
+  const index = await getTimetableAssetIndex();
+  const asset = index.assets.find((stored) => stored.id === id);
+  if (!asset) {
+    throw new Error("저장된 시간표를 찾지 못했습니다.");
+  }
+
+  await setTimetableAssetIndex(replaceAsset(index, asset, true));
+}
+
+async function deleteTimetableById(id: string): Promise<void> {
+  const index = await getTimetableAssetIndex();
+  const asset = index.assets.find((stored) => stored.id === id);
+  if (!asset) {
+    return;
+  }
+
+  if (asset.source === "upload") {
+    await runTransaction<undefined>("readwrite", (store) => store.delete(id));
+  }
+
+  const assets = index.assets.filter((stored) => stored.id !== id);
+  const nextAssetIndex: TimetableAssetIndex = {
+    schemaVersion: 3,
+    activeAssetId:
+      index.activeAssetId === id
+        ? (assets[0]?.id ?? null)
+        : index.activeAssetId,
+    assets,
+  };
+
+  if (asset.source === "everytime") {
+    const overrideIndex = await getEverytimeTimetableOverrideIndex();
+    const overrides = { ...overrideIndex.overrides };
+    delete overrides[id];
+    await setTimetableSettings({
+      [TIMETABLE_STORAGE_KEYS.assetIndex]: nextAssetIndex,
+      [TIMETABLE_STORAGE_KEYS.everytimeOverrides]: {
+        schemaVersion: 1,
+        overrides,
+      } satisfies EverytimeTimetableOverrideIndex,
+    });
+    return;
+  }
+
+  await setTimetableAssetIndex(nextAssetIndex);
+}
+
+export async function deleteActiveTimetable(): Promise<void> {
+  const index = await getTimetableAssetIndex();
+  if (index.activeAssetId) {
+    await deleteTimetableById(index.activeAssetId);
+  }
+}
+
+export async function getImportedEverytimeSemesters(): Promise<string[]> {
+  return (
+    (await getTimetableSetting<string[]>(
+      TIMETABLE_STORAGE_KEYS.everytimeImportedSemesters,
+    )) ?? []
+  );
+}
+
+export async function markEverytimeSemestersImported(
+  semesters: string[],
+): Promise<void> {
+  const importedSemesters = await getImportedEverytimeSemesters();
+  await setTimetableSettings({
+    [TIMETABLE_STORAGE_KEYS.everytimeImportedSemesters]: [
+      ...new Set([...importedSemesters, ...semesters]),
+    ],
+  });
+}

--- a/src/utils/timetableStorage.ts
+++ b/src/utils/timetableStorage.ts
@@ -20,71 +20,44 @@ import {
   isEverytimeTimetableOverrideEmpty,
   mergeEverytimeTimetable,
 } from "@/utils/everytimeTimetable";
+import {
+  resolveTimetableAssetIndex,
+  replaceTimetableAsset,
+  type TimetableAssetIndexResolution,
+} from "@/utils/timetableStorageSchema";
 
 const DATABASE_NAME = "linku-timetable";
 const DATABASE_VERSION = 1;
 const ASSET_STORE_NAME = "assets";
-const UPLOADED_TIMETABLE_ASSET_ID = "uploaded";
+const UPLOADED_TIMETABLE_ASSET_PREFIX = "upload:";
 const EVERYTIME_TIMETABLE_ASSET_PREFIX = "everytime:";
+const TIMETABLE_STORAGE_LOCK_NAME = "linku:timetable-storage";
 
 interface TimetableBlobRecord {
   id: string;
   blob: Blob;
 }
 
-interface LegacyTimetableAssetMeta {
-  id: string;
-  source: "upload" | "everytime-capture";
-  semester?: string;
-  mimeType: "image/png";
-  width: number;
-  height: number;
-  byteSize: number;
-  checksum: string;
-  syncStatus: "local" | "pending" | "synced" | "error";
-  createdAt: string;
-  updatedAt: string;
+let inProcessMutationQueue: Promise<void> = Promise.resolve();
+
+function withInProcessMutationQueue<T>(operation: () => Promise<T>): Promise<T> {
+  const result = inProcessMutationQueue.then(operation, operation);
+  inProcessMutationQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
 }
 
-interface LegacyTimetableAssetIndex {
-  schemaVersion: 1;
-  activeAssetId: string | null;
-  assets: LegacyTimetableAssetMeta[];
-}
+function withTimetableStorageLock<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lockManager = globalThis.navigator?.locks;
+  if (lockManager) {
+    return lockManager.request(TIMETABLE_STORAGE_LOCK_NAME, operation);
+  }
 
-interface LegacyV2TimetableMetaBase {
-  schemaVersion: 2;
-  id: string;
-  source: "upload" | "everytime";
-  semester?: string;
-  syncStatus: "local" | "pending" | "synced" | "error";
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface LegacyV2UploadedTimetableMeta extends LegacyV2TimetableMetaBase {
-  source: "upload";
-  mimeType: "image/png";
-  width: number;
-  height: number;
-  byteSize: number;
-  checksum: string;
-}
-
-interface LegacyV2EverytimeTimetableMeta extends LegacyV2TimetableMetaBase {
-  source: "everytime";
-  timetable: EverytimeTimetable;
-  checksum: string;
-}
-
-type LegacyV2TimetableAssetMeta =
-  | LegacyV2UploadedTimetableMeta
-  | LegacyV2EverytimeTimetableMeta;
-
-interface LegacyV2TimetableAssetIndex {
-  schemaVersion: 2;
-  activeAssetId: string | null;
-  assets: LegacyV2TimetableAssetMeta[];
+  return withInProcessMutationQueue(operation);
 }
 
 function hasExtensionStorage(): boolean {
@@ -124,136 +97,34 @@ async function removeTimetableSetting(key: string): Promise<void> {
   localStorage.removeItem(key);
 }
 
-function isTimetableAssetIndex(value: unknown): value is TimetableAssetIndex {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "schemaVersion" in value &&
-    value.schemaVersion === 3 &&
-    "assets" in value &&
-    Array.isArray(value.assets)
-  );
+async function readTimetableAssetIndexResolution(): Promise<
+  TimetableAssetIndexResolution
+> {
+  const [storedIndex, storedLegacyMeta] = await Promise.all([
+    getTimetableSetting<unknown>(TIMETABLE_STORAGE_KEYS.assetIndex),
+    getTimetableSetting<unknown>(TIMETABLE_STORAGE_KEYS.legacyMeta),
+  ]);
+  return resolveTimetableAssetIndex(storedIndex, storedLegacyMeta);
 }
 
-function isLegacyV2TimetableAssetIndex(
-  value: unknown,
-): value is LegacyV2TimetableAssetIndex {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "schemaVersion" in value &&
-    value.schemaVersion === 2 &&
-    "assets" in value &&
-    Array.isArray(value.assets)
-  );
-}
-
-function isLegacyTimetableAssetIndex(
-  value: unknown,
-): value is LegacyTimetableAssetIndex {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "schemaVersion" in value &&
-    value.schemaVersion === 1 &&
-    "assets" in value &&
-    Array.isArray(value.assets)
-  );
-}
-
-function createEmptyAssetIndex(): TimetableAssetIndex {
-  return {
-    schemaVersion: 3,
-    activeAssetId: null,
-    assets: [],
-  };
-}
-
-function migrateLegacyAsset(
-  legacy: LegacyTimetableAssetMeta,
-): UploadedTimetableMeta {
-  return {
-    schemaVersion: 3,
-    id: legacy.id,
-    source: "upload",
-    mimeType: "image/png",
-    width: legacy.width,
-    height: legacy.height,
-    byteSize: legacy.byteSize,
-    checksum: legacy.checksum,
-    syncStatus: legacy.syncStatus,
-    createdAt: legacy.createdAt,
-    updatedAt: legacy.updatedAt,
-  };
-}
-
-function migrateV2Asset(
-  legacy: LegacyV2TimetableAssetMeta,
-): TimetableAssetMeta {
-  if (legacy.source === "everytime") {
-    return {
-      schemaVersion: 3,
-      id: legacy.id,
-      source: "everytime",
-      semester: legacy.semester,
-      snapshot: legacy.timetable,
-      snapshotChecksum: legacy.checksum,
-      syncStatus: legacy.syncStatus,
-      createdAt: legacy.createdAt,
-      updatedAt: legacy.updatedAt,
-    };
+async function getTimetableAssetIndexUnlocked(): Promise<TimetableAssetIndex> {
+  const resolution = await readTimetableAssetIndexResolution();
+  if (resolution.shouldPersist) {
+    await setTimetableAssetIndex(resolution.index);
   }
-
-  return {
-    ...legacy,
-    schemaVersion: 3,
-  };
+  if (resolution.shouldRemoveLegacyMeta) {
+    await removeTimetableSetting(TIMETABLE_STORAGE_KEYS.legacyMeta);
+  }
+  return resolution.index;
 }
 
 async function getTimetableAssetIndex(): Promise<TimetableAssetIndex> {
-  const storedIndex = await getTimetableSetting<unknown>(
-    TIMETABLE_STORAGE_KEYS.assetIndex,
-  );
-  if (isTimetableAssetIndex(storedIndex)) {
-    return storedIndex;
+  const resolution = await readTimetableAssetIndexResolution();
+  if (!resolution.shouldPersist && !resolution.shouldRemoveLegacyMeta) {
+    return resolution.index;
   }
 
-  if (isLegacyV2TimetableAssetIndex(storedIndex)) {
-    const migratedIndex: TimetableAssetIndex = {
-      schemaVersion: 3,
-      activeAssetId: storedIndex.activeAssetId,
-      assets: storedIndex.assets.map(migrateV2Asset),
-    };
-    await setTimetableAssetIndex(migratedIndex);
-    return migratedIndex;
-  }
-
-  const legacyIndex = isLegacyTimetableAssetIndex(storedIndex)
-    ? storedIndex
-    : undefined;
-  const legacyMeta = legacyIndex
-    ? undefined
-    : await getTimetableSetting<LegacyTimetableAssetMeta>(
-        TIMETABLE_STORAGE_KEYS.legacyMeta,
-      );
-  const legacyAssets = legacyIndex?.assets ?? (legacyMeta ? [legacyMeta] : []);
-
-  if (legacyAssets.length === 0) {
-    return createEmptyAssetIndex();
-  }
-
-  const migratedIndex: TimetableAssetIndex = {
-    schemaVersion: 3,
-    activeAssetId: legacyIndex?.activeAssetId ?? legacyMeta?.id ?? null,
-    assets: legacyAssets.map(migrateLegacyAsset),
-  };
-
-  await setTimetableSettings({
-    [TIMETABLE_STORAGE_KEYS.assetIndex]: migratedIndex,
-  });
-  await removeTimetableSetting(TIMETABLE_STORAGE_KEYS.legacyMeta);
-
-  return migratedIndex;
+  return withTimetableStorageLock(getTimetableAssetIndexUnlocked);
 }
 
 async function setTimetableAssetIndex(
@@ -307,6 +178,7 @@ async function setEverytimeTimetableOverrideIndex(
 function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    let blocked = false;
 
     request.onupgradeneeded = () => {
       const database = request.result;
@@ -315,9 +187,23 @@ function openDatabase(): Promise<IDBDatabase> {
       }
     };
 
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      if (blocked) {
+        request.result.close();
+        return;
+      }
+      resolve(request.result);
+    };
     request.onerror = () =>
       reject(request.error ?? new Error("시간표 저장소를 열 수 없습니다."));
+    request.onblocked = () => {
+      blocked = true;
+      reject(
+        new Error(
+          "다른 시간표 화면이 저장소를 사용 중입니다. 창을 닫고 다시 시도해주세요.",
+        ),
+      );
+    };
   });
 }
 
@@ -332,24 +218,31 @@ function runTransaction<T>(
         const store = transaction.objectStore(ASSET_STORE_NAME);
         const request = operation(store);
         let result: T;
+        let settled = false;
+
+        const fail = (error?: DOMException | null): void => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          database.close();
+          reject(error ?? new Error("시간표 저장에 실패했습니다."));
+        };
 
         request.onsuccess = () => {
           result = request.result;
         };
-        request.onerror = () => {
-          database.close();
-          reject(request.error ?? new Error("시간표 저장에 실패했습니다."));
-        };
+        request.onerror = () => fail(request.error);
         transaction.oncomplete = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
           database.close();
           resolve(result);
         };
-        transaction.onerror = () => {
-          database.close();
-          reject(
-            transaction.error ?? new Error("시간표 저장에 실패했습니다."),
-          );
-        };
+        transaction.onerror = () => fail(transaction.error);
+        transaction.onabort = () => fail(transaction.error);
       }),
   );
 }
@@ -366,8 +259,8 @@ async function calculateChecksum(value: Blob | string): Promise<string> {
     .join("");
 }
 
-function getAssetId(input: SaveTimetableInput): string {
-  return input.id ?? UPLOADED_TIMETABLE_ASSET_ID;
+function getAssetId(input: SaveTimetableInput, checksum: string): string {
+  return input.id ?? `${UPLOADED_TIMETABLE_ASSET_PREFIX}${checksum}`;
 }
 
 function assertUniqueAddedIds(
@@ -406,19 +299,6 @@ function validateOverrideAdditions(
   );
 }
 
-function replaceAsset(
-  index: TimetableAssetIndex,
-  asset: TimetableAssetMeta,
-  activate: boolean,
-): TimetableAssetIndex {
-  return {
-    schemaVersion: 3,
-    activeAssetId:
-      activate || !index.activeAssetId ? asset.id : index.activeAssetId,
-    assets: [asset, ...index.assets.filter((stored) => stored.id !== asset.id)],
-  };
-}
-
 export function getEverytimeTimetableAssetId(semester: string): string {
   return `${EVERYTIME_TIMETABLE_ASSET_PREFIX}${semester}`;
 }
@@ -427,58 +307,69 @@ export async function saveTimetableAsset(
   blob: Blob,
   input: SaveTimetableInput,
 ): Promise<{ meta: UploadedTimetableMeta; changed: boolean }> {
-  if (!isTimetableImageMimeType(blob.type)) {
+  const mimeType = blob.type;
+  if (!isTimetableImageMimeType(mimeType)) {
     throw new Error("지원하지 않는 이미지 형식입니다.");
   }
 
-  const id = getAssetId(input);
   const checksum = await calculateChecksum(blob);
-  const index = await getTimetableAssetIndex();
-  const previousMeta = index.assets.find(
-    (asset): asset is UploadedTimetableMeta =>
-      asset.id === id && asset.source === "upload",
-  );
+  const id = getAssetId(input, checksum);
 
-  if (previousMeta?.checksum === checksum) {
-    const existingRecord = await runTransaction<
+  return withTimetableStorageLock(async () => {
+    const index = await getTimetableAssetIndexUnlocked();
+    const previousMeta = index.assets.find(
+      (asset): asset is UploadedTimetableMeta =>
+        asset.id === id && asset.source === "upload",
+    );
+    const previousRecord = await runTransaction<
       TimetableBlobRecord | undefined
     >("readonly", (store) => store.get(id));
 
-    if (existingRecord?.blob) {
+    if (previousMeta?.checksum === checksum && previousRecord?.blob) {
       if (index.activeAssetId !== id) {
-        await setTimetableAssetIndex(replaceAsset(index, previousMeta, true));
+        await setTimetableAssetIndex(
+          replaceTimetableAsset(index, previousMeta, true),
+        );
       }
       return { meta: previousMeta, changed: false };
     }
-  }
 
-  const now = new Date().toISOString();
-  const meta: UploadedTimetableMeta = {
-    schemaVersion: 3,
-    id,
-    source: "upload",
-    mimeType: blob.type,
-    width: input.width,
-    height: input.height,
-    byteSize: blob.size,
-    checksum,
-    syncStatus: "local",
-    createdAt: previousMeta?.createdAt ?? now,
-    updatedAt: now,
-  };
+    const now = new Date().toISOString();
+    const meta: UploadedTimetableMeta = {
+      schemaVersion: 3,
+      id,
+      source: "upload",
+      mimeType,
+      width: input.width,
+      height: input.height,
+      byteSize: blob.size,
+      checksum,
+      syncStatus: "local",
+      createdAt: previousMeta?.createdAt ?? now,
+      updatedAt: now,
+    };
 
-  await runTransaction<IDBValidKey>("readwrite", (store) =>
-    store.put({ id, blob } satisfies TimetableBlobRecord),
-  );
+    await runTransaction<IDBValidKey>("readwrite", (store) =>
+      store.put({ id, blob } satisfies TimetableBlobRecord),
+    );
 
-  try {
-    await setTimetableAssetIndex(replaceAsset(index, meta, true));
-  } catch (error) {
-    await runTransaction<undefined>("readwrite", (store) => store.delete(id));
-    throw error;
-  }
+    try {
+      await setTimetableAssetIndex(replaceTimetableAsset(index, meta, true));
+    } catch (error) {
+      if (previousRecord) {
+        await runTransaction<IDBValidKey>("readwrite", (store) =>
+          store.put(previousRecord),
+        );
+      } else {
+        await runTransaction<undefined>("readwrite", (store) =>
+          store.delete(id),
+        );
+      }
+      throw error;
+    }
 
-  return { meta, changed: true };
+    return { meta, changed: true };
+  });
 }
 
 export async function saveEverytimeTimetable(
@@ -486,31 +377,34 @@ export async function saveEverytimeTimetable(
 ): Promise<{ meta: EverytimeTimetableMeta; changed: boolean }> {
   const id = getEverytimeTimetableAssetId(snapshot.semester);
   const snapshotChecksum = await calculateChecksum(JSON.stringify(snapshot));
-  const index = await getTimetableAssetIndex();
-  const previousMeta = index.assets.find(
-    (asset): asset is EverytimeTimetableMeta =>
-      asset.id === id && asset.source === "everytime",
-  );
 
-  if (previousMeta?.snapshotChecksum === snapshotChecksum) {
-    return { meta: previousMeta, changed: false };
-  }
+  return withTimetableStorageLock(async () => {
+    const index = await getTimetableAssetIndexUnlocked();
+    const previousMeta = index.assets.find(
+      (asset): asset is EverytimeTimetableMeta =>
+        asset.id === id && asset.source === "everytime",
+    );
 
-  const now = new Date().toISOString();
-  const meta: EverytimeTimetableMeta = {
-    schemaVersion: 3,
-    id,
-    source: "everytime",
-    semester: snapshot.semester,
-    snapshot,
-    snapshotChecksum,
-    syncStatus: "local",
-    createdAt: previousMeta?.createdAt ?? now,
-    updatedAt: now,
-  };
+    if (previousMeta?.snapshotChecksum === snapshotChecksum) {
+      return { meta: previousMeta, changed: false };
+    }
 
-  await setTimetableAssetIndex(replaceAsset(index, meta, false));
-  return { meta, changed: true };
+    const now = new Date().toISOString();
+    const meta: EverytimeTimetableMeta = {
+      schemaVersion: 3,
+      id,
+      source: "everytime",
+      semester: snapshot.semester,
+      snapshot,
+      snapshotChecksum,
+      syncStatus: "local",
+      createdAt: previousMeta?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    await setTimetableAssetIndex(replaceTimetableAsset(index, meta, false));
+    return { meta, changed: true };
+  });
 }
 
 export async function getEverytimeTimetableOverride(
@@ -524,43 +418,47 @@ export async function saveEverytimeTimetableOverride(
   assetId: string,
   input: EverytimeTimetableOverrideInput,
 ): Promise<EverytimeTimetableOverride | null> {
-  const assetIndex = await getTimetableAssetIndex();
-  const asset = assetIndex.assets.find((candidate) => candidate.id === assetId);
-  if (asset?.source !== "everytime") {
-    throw new Error("사용자 수정을 저장할 에브리타임 시간표를 찾지 못했습니다.");
-  }
-  validateOverrideAdditions(asset.snapshot, input);
+  return withTimetableStorageLock(async () => {
+    const assetIndex = await getTimetableAssetIndexUnlocked();
+    const asset = assetIndex.assets.find((candidate) => candidate.id === assetId);
+    if (asset?.source !== "everytime") {
+      throw new Error("사용자 수정을 저장할 에브리타임 시간표를 찾지 못했습니다.");
+    }
+    validateOverrideAdditions(asset.snapshot, input);
 
-  const overrideIndex = await getEverytimeTimetableOverrideIndex();
-  const override = createEverytimeTimetableOverride(assetId, input);
-  const overrides = { ...overrideIndex.overrides };
+    const overrideIndex = await getEverytimeTimetableOverrideIndex();
+    const override = createEverytimeTimetableOverride(assetId, input);
+    const overrides = { ...overrideIndex.overrides };
 
-  if (isEverytimeTimetableOverrideEmpty(override)) {
-    delete overrides[assetId];
-  } else {
-    overrides[assetId] = override;
-  }
+    if (isEverytimeTimetableOverrideEmpty(override)) {
+      delete overrides[assetId];
+    } else {
+      overrides[assetId] = override;
+    }
 
-  await setEverytimeTimetableOverrideIndex({
-    schemaVersion: 1,
-    overrides,
+    await setEverytimeTimetableOverrideIndex({
+      schemaVersion: 1,
+      overrides,
+    });
+    return overrides[assetId] ?? null;
   });
-  return overrides[assetId] ?? null;
 }
 
 export async function clearEverytimeTimetableOverride(
   assetId: string,
 ): Promise<void> {
-  const overrideIndex = await getEverytimeTimetableOverrideIndex();
-  if (!overrideIndex.overrides[assetId]) {
-    return;
-  }
+  await withTimetableStorageLock(async () => {
+    const overrideIndex = await getEverytimeTimetableOverrideIndex();
+    if (!overrideIndex.overrides[assetId]) {
+      return;
+    }
 
-  const overrides = { ...overrideIndex.overrides };
-  delete overrides[assetId];
-  await setEverytimeTimetableOverrideIndex({
-    schemaVersion: 1,
-    overrides,
+    const overrides = { ...overrideIndex.overrides };
+    delete overrides[assetId];
+    await setEverytimeTimetableOverrideIndex({
+      schemaVersion: 1,
+      overrides,
+    });
   });
 }
 
@@ -594,11 +492,17 @@ export async function getActiveTimetable(): Promise<
   );
 
   if (!record?.blob) {
-    const assets = index.assets.filter((asset) => asset.id !== meta.id);
-    await setTimetableAssetIndex({
-      schemaVersion: 3,
-      activeAssetId: assets[0]?.id ?? null,
-      assets,
+    await withTimetableStorageLock(async () => {
+      const latestIndex = await getTimetableAssetIndexUnlocked();
+      const assets = latestIndex.assets.filter((asset) => asset.id !== meta.id);
+      await setTimetableAssetIndex({
+        schemaVersion: 3,
+        activeAssetId:
+          latestIndex.activeAssetId === meta.id
+            ? (assets[0]?.id ?? null)
+            : latestIndex.activeAssetId,
+        assets,
+      });
     });
     return null;
   }
@@ -607,23 +511,30 @@ export async function getActiveTimetable(): Promise<
 }
 
 export async function setActiveTimetable(id: string): Promise<void> {
-  const index = await getTimetableAssetIndex();
-  const asset = index.assets.find((stored) => stored.id === id);
-  if (!asset) {
-    throw new Error("저장된 시간표를 찾지 못했습니다.");
-  }
+  await withTimetableStorageLock(async () => {
+    const index = await getTimetableAssetIndexUnlocked();
+    const asset = index.assets.find((stored) => stored.id === id);
+    if (!asset) {
+      throw new Error("저장된 시간표를 찾지 못했습니다.");
+    }
 
-  await setTimetableAssetIndex(replaceAsset(index, asset, true));
+    await setTimetableAssetIndex(replaceTimetableAsset(index, asset, true));
+  });
 }
 
-async function deleteTimetableById(id: string): Promise<void> {
-  const index = await getTimetableAssetIndex();
+async function deleteTimetableByIdUnlocked(id: string): Promise<void> {
+  const index = await getTimetableAssetIndexUnlocked();
   const asset = index.assets.find((stored) => stored.id === id);
   if (!asset) {
     return;
   }
 
+  let uploadedRecord: TimetableBlobRecord | undefined;
   if (asset.source === "upload") {
+    uploadedRecord = await runTransaction<TimetableBlobRecord | undefined>(
+      "readonly",
+      (store) => store.get(id),
+    );
     await runTransaction<undefined>("readwrite", (store) => store.delete(id));
   }
 
@@ -651,14 +562,25 @@ async function deleteTimetableById(id: string): Promise<void> {
     return;
   }
 
-  await setTimetableAssetIndex(nextAssetIndex);
+  try {
+    await setTimetableAssetIndex(nextAssetIndex);
+  } catch (error) {
+    if (uploadedRecord) {
+      await runTransaction<IDBValidKey>("readwrite", (store) =>
+        store.put(uploadedRecord),
+      );
+    }
+    throw error;
+  }
 }
 
 export async function deleteActiveTimetable(): Promise<void> {
-  const index = await getTimetableAssetIndex();
-  if (index.activeAssetId) {
-    await deleteTimetableById(index.activeAssetId);
-  }
+  await withTimetableStorageLock(async () => {
+    const index = await getTimetableAssetIndexUnlocked();
+    if (index.activeAssetId) {
+      await deleteTimetableByIdUnlocked(index.activeAssetId);
+    }
+  });
 }
 
 export async function getImportedEverytimeSemesters(): Promise<string[]> {
@@ -672,10 +594,12 @@ export async function getImportedEverytimeSemesters(): Promise<string[]> {
 export async function markEverytimeSemestersImported(
   semesters: string[],
 ): Promise<void> {
-  const importedSemesters = await getImportedEverytimeSemesters();
-  await setTimetableSettings({
-    [TIMETABLE_STORAGE_KEYS.everytimeImportedSemesters]: [
-      ...new Set([...importedSemesters, ...semesters]),
-    ],
+  await withTimetableStorageLock(async () => {
+    const importedSemesters = await getImportedEverytimeSemesters();
+    await setTimetableSettings({
+      [TIMETABLE_STORAGE_KEYS.everytimeImportedSemesters]: [
+        ...new Set([...importedSemesters, ...semesters]),
+      ],
+    });
   });
 }

--- a/src/utils/timetableStorage.ts
+++ b/src/utils/timetableStorage.ts
@@ -10,7 +10,10 @@ import type {
   TimetableAssetMeta,
   UploadedTimetableMeta,
 } from "@/types/timetable";
-import { TIMETABLE_STORAGE_KEYS } from "@/types/timetable";
+import {
+  isTimetableImageMimeType,
+  TIMETABLE_STORAGE_KEYS,
+} from "@/types/timetable";
 import { getStorage, removeStorage, setStorage } from "@/utils/chrome";
 import {
   createEverytimeTimetableOverride,
@@ -424,8 +427,8 @@ export async function saveTimetableAsset(
   blob: Blob,
   input: SaveTimetableInput,
 ): Promise<{ meta: UploadedTimetableMeta; changed: boolean }> {
-  if (blob.type !== "image/png") {
-    throw new Error("PNG 파일만 저장할 수 있습니다.");
+  if (!isTimetableImageMimeType(blob.type)) {
+    throw new Error("지원하지 않는 이미지 형식입니다.");
   }
 
   const id = getAssetId(input);
@@ -454,7 +457,7 @@ export async function saveTimetableAsset(
     schemaVersion: 3,
     id,
     source: "upload",
-    mimeType: "image/png",
+    mimeType: blob.type,
     width: input.width,
     height: input.height,
     byteSize: blob.size,

--- a/src/utils/timetableStorageSchema.ts
+++ b/src/utils/timetableStorageSchema.ts
@@ -1,0 +1,336 @@
+import type {
+  TimetableAssetIndex,
+  TimetableAssetMeta,
+  UploadedTimetableMeta,
+} from "@/types/timetable";
+import { isTimetableImageMimeType } from "../types/timetable.ts";
+
+interface LegacyTimetableAssetMeta {
+  id: string;
+  source: "upload" | "everytime-capture";
+  semester?: string;
+  mimeType: "image/png";
+  width: number;
+  height: number;
+  byteSize: number;
+  checksum: string;
+  syncStatus: "local" | "pending" | "synced" | "error";
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface LegacyTimetableAssetIndex {
+  schemaVersion: 1;
+  activeAssetId: string | null;
+  assets: LegacyTimetableAssetMeta[];
+}
+
+interface LegacyV2TimetableMetaBase {
+  schemaVersion: 2;
+  id: string;
+  source: "upload" | "everytime";
+  semester?: string;
+  syncStatus: "local" | "pending" | "synced" | "error";
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface LegacyV2UploadedTimetableMeta extends LegacyV2TimetableMetaBase {
+  source: "upload";
+  mimeType: "image/png";
+  width: number;
+  height: number;
+  byteSize: number;
+  checksum: string;
+}
+
+interface LegacyV2EverytimeTimetableMeta extends LegacyV2TimetableMetaBase {
+  source: "everytime";
+  timetable: Extract<TimetableAssetMeta, { source: "everytime" }>["snapshot"];
+  checksum: string;
+}
+
+type LegacyV2TimetableAssetMeta =
+  | LegacyV2UploadedTimetableMeta
+  | LegacyV2EverytimeTimetableMeta;
+
+interface LegacyV2TimetableAssetIndex {
+  schemaVersion: 2;
+  activeAssetId: string | null;
+  assets: LegacyV2TimetableAssetMeta[];
+}
+
+export interface TimetableAssetIndexResolution {
+  index: TimetableAssetIndex;
+  shouldPersist: boolean;
+  shouldRemoveLegacyMeta: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasAssetArray(
+  value: unknown,
+): value is Record<string, unknown> & { assets: unknown[] } {
+  return isRecord(value) && Array.isArray(value.assets);
+}
+
+function isTimetableAssetIndex(value: unknown): value is TimetableAssetIndex {
+  return (
+    hasAssetArray(value) &&
+    value.schemaVersion === 3 &&
+    (typeof value.activeAssetId === "string" || value.activeAssetId === null) &&
+    value.assets.every(isTimetableAssetMeta)
+  );
+}
+
+function hasTimetableMetaBase(value: unknown): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 3 &&
+    typeof value.id === "string" &&
+    typeof value.createdAt === "string" &&
+    typeof value.updatedAt === "string" &&
+    (value.syncStatus === "local" ||
+      value.syncStatus === "pending" ||
+      value.syncStatus === "synced" ||
+      value.syncStatus === "error")
+  );
+}
+
+function isEverytimeTimetableSnapshot(
+  value: unknown,
+): value is Extract<TimetableAssetMeta, { source: "everytime" }>[
+  "snapshot"
+] {
+  return (
+    isRecord(value) &&
+    typeof value.semester === "string" &&
+    Array.isArray(value.weekdays) &&
+    Array.isArray(value.subjects)
+  );
+}
+
+function isTimetableAssetMeta(value: unknown): value is TimetableAssetMeta {
+  if (!hasTimetableMetaBase(value)) {
+    return false;
+  }
+
+  if (value.source === "upload") {
+    return (
+      typeof value.mimeType === "string" &&
+      isTimetableImageMimeType(value.mimeType) &&
+      typeof value.width === "number" &&
+      typeof value.height === "number" &&
+      typeof value.byteSize === "number" &&
+      typeof value.checksum === "string"
+    );
+  }
+
+  if (value.source !== "everytime") {
+    return false;
+  }
+
+  return (
+    typeof value.snapshotChecksum === "string" &&
+    isEverytimeTimetableSnapshot(value.snapshot)
+  );
+}
+
+function isLegacyV2TimetableAssetIndex(
+  value: unknown,
+): value is LegacyV2TimetableAssetIndex {
+  return (
+    hasAssetArray(value) &&
+    value.schemaVersion === 2 &&
+    (typeof value.activeAssetId === "string" || value.activeAssetId === null) &&
+    value.assets.every(isLegacyV2TimetableAssetMeta)
+  );
+}
+
+function isLegacyTimetableAssetIndex(
+  value: unknown,
+): value is LegacyTimetableAssetIndex {
+  return (
+    hasAssetArray(value) &&
+    value.schemaVersion === 1 &&
+    (typeof value.activeAssetId === "string" || value.activeAssetId === null) &&
+    value.assets.every(isLegacyTimetableAssetMeta)
+  );
+}
+
+function hasLegacyV2TimetableMetaBase(
+  value: unknown,
+): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 2 &&
+    typeof value.id === "string" &&
+    typeof value.createdAt === "string" &&
+    typeof value.updatedAt === "string" &&
+    (value.syncStatus === "local" ||
+      value.syncStatus === "pending" ||
+      value.syncStatus === "synced" ||
+      value.syncStatus === "error")
+  );
+}
+
+function isLegacyV2TimetableAssetMeta(
+  value: unknown,
+): value is LegacyV2TimetableAssetMeta {
+  if (!hasLegacyV2TimetableMetaBase(value)) {
+    return false;
+  }
+
+  if (value.source === "upload") {
+    return (
+      value.mimeType === "image/png" &&
+      typeof value.width === "number" &&
+      typeof value.height === "number" &&
+      typeof value.byteSize === "number" &&
+      typeof value.checksum === "string"
+    );
+  }
+
+  return (
+    value.source === "everytime" &&
+    isEverytimeTimetableSnapshot(value.timetable) &&
+    typeof value.checksum === "string"
+  );
+}
+
+function isLegacyTimetableAssetMeta(
+  value: unknown,
+): value is LegacyTimetableAssetMeta {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (value.source === "upload" || value.source === "everytime-capture") &&
+    value.mimeType === "image/png" &&
+    typeof value.width === "number" &&
+    typeof value.height === "number" &&
+    typeof value.byteSize === "number" &&
+    typeof value.checksum === "string" &&
+    (value.syncStatus === "local" ||
+      value.syncStatus === "pending" ||
+      value.syncStatus === "synced" ||
+      value.syncStatus === "error") &&
+    typeof value.createdAt === "string" &&
+    typeof value.updatedAt === "string"
+  );
+}
+
+export function createEmptyTimetableAssetIndex(): TimetableAssetIndex {
+  return {
+    schemaVersion: 3,
+    activeAssetId: null,
+    assets: [],
+  };
+}
+
+export function replaceTimetableAsset(
+  index: TimetableAssetIndex,
+  asset: TimetableAssetMeta,
+  activate: boolean,
+): TimetableAssetIndex {
+  return {
+    schemaVersion: 3,
+    activeAssetId:
+      activate || !index.activeAssetId ? asset.id : index.activeAssetId,
+    assets: [asset, ...index.assets.filter((stored) => stored.id !== asset.id)],
+  };
+}
+
+function migrateLegacyAsset(
+  legacy: LegacyTimetableAssetMeta,
+): UploadedTimetableMeta {
+  return {
+    schemaVersion: 3,
+    id: legacy.id,
+    source: "upload",
+    mimeType: "image/png",
+    width: legacy.width,
+    height: legacy.height,
+    byteSize: legacy.byteSize,
+    checksum: legacy.checksum,
+    syncStatus: legacy.syncStatus,
+    createdAt: legacy.createdAt,
+    updatedAt: legacy.updatedAt,
+  };
+}
+
+function migrateV2Asset(
+  legacy: LegacyV2TimetableAssetMeta,
+): TimetableAssetMeta {
+  if (legacy.source === "everytime") {
+    return {
+      schemaVersion: 3,
+      id: legacy.id,
+      source: "everytime",
+      semester: legacy.semester,
+      snapshot: legacy.timetable,
+      snapshotChecksum: legacy.checksum,
+      syncStatus: legacy.syncStatus,
+      createdAt: legacy.createdAt,
+      updatedAt: legacy.updatedAt,
+    };
+  }
+
+  return {
+    ...legacy,
+    schemaVersion: 3,
+  };
+}
+
+export function resolveTimetableAssetIndex(
+  storedIndex: unknown,
+  storedLegacyMeta?: unknown,
+): TimetableAssetIndexResolution {
+  if (isTimetableAssetIndex(storedIndex)) {
+    return {
+      index: storedIndex,
+      shouldPersist: false,
+      shouldRemoveLegacyMeta: false,
+    };
+  }
+
+  if (isLegacyV2TimetableAssetIndex(storedIndex)) {
+    return {
+      index: {
+        schemaVersion: 3,
+        activeAssetId: storedIndex.activeAssetId,
+        assets: storedIndex.assets.map(migrateV2Asset),
+      },
+      shouldPersist: true,
+      shouldRemoveLegacyMeta: false,
+    };
+  }
+
+  const legacyIndex = isLegacyTimetableAssetIndex(storedIndex)
+    ? storedIndex
+    : undefined;
+  const legacyMeta =
+    !legacyIndex && isLegacyTimetableAssetMeta(storedLegacyMeta)
+      ? storedLegacyMeta
+      : undefined;
+  const legacyAssets = legacyIndex?.assets ?? (legacyMeta ? [legacyMeta] : []);
+
+  if (legacyAssets.length === 0) {
+    return {
+      index: createEmptyTimetableAssetIndex(),
+      shouldPersist: false,
+      shouldRemoveLegacyMeta: false,
+    };
+  }
+
+  return {
+    index: {
+      schemaVersion: 3,
+      activeAssetId: legacyIndex?.activeAssetId ?? legacyMeta?.id ?? null,
+      assets: legacyAssets.map(migrateLegacyAsset),
+    },
+    shouldPersist: true,
+    shouldRemoveLegacyMeta: Boolean(legacyMeta),
+  };
+}

--- a/tests/fixtures/everytime-table-list.xml
+++ b/tests/fixtures/everytime-table-list.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <table id="primary-legacy" name="기본 시간표" primary="1" />
+  <table id="secondary" name="다른 시간표" primary="0" />
+  <table id="primary-current" name="새 속성 시간표" is_primary="1" />
+</response>

--- a/tests/fixtures/everytime-timetable.html
+++ b/tests/fixtures/everytime-timetable.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="ko">
+  <body>
+    <select id="semesters">
+      <option selected>2025년 2학기</option>
+    </select>
+    <div id="container" class="timetable">
+      <table class="tablehead">
+        <tr><th>월</th><th>화</th><th>수</th><th>목</th><th>금</th><th>토</th><th>일</th></tr>
+      </table>
+      <table class="tablebody">
+        <tr>
+          <td><div class="grids"><div class="grid"></div></div><div class="cols"><div class="subject color5" style="top: 450px; height: 75px"><h3>자료구조</h3><p><em>김교수</em> 공학관 101호</p></div></div></td>
+          <td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>

--- a/tests/timetable/everytimeSemester.test.ts
+++ b/tests/timetable/everytimeSemester.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatEverytimeSemester,
+  getLatestEverytimeSemesterAnchor,
+  parseEverytimeSemester,
+} from "../../src/utils/everytimeSemester.ts";
+
+test("에브리타임 학기 문자열을 구조화한다", () => {
+  assert.deepEqual(parseEverytimeSemester("2026년 여름학기"), {
+    label: "2026년 여름학기",
+    year: 2026,
+    term: "여름",
+    sortKey: 2026 * 4 + 1,
+  });
+  assert.equal(parseEverytimeSemester("2026년 3학기"), null);
+  assert.equal(formatEverytimeSemester(2025, "겨울"), "2025년 겨울학기");
+});
+
+test("학사 시기별 최신 탐색 기준을 선택한다", () => {
+  assert.deepEqual(getLatestEverytimeSemesterAnchor(new Date(2026, 0, 1)), {
+    year: 2026,
+    term: "1",
+    sortKey: 2026 * 4,
+  });
+  assert.equal(
+    getLatestEverytimeSemesterAnchor(new Date(2026, 4, 31)).term,
+    "1",
+  );
+  assert.equal(
+    getLatestEverytimeSemesterAnchor(new Date(2026, 5, 1)).term,
+    "2",
+  );
+  assert.equal(
+    getLatestEverytimeSemesterAnchor(new Date(2026, 10, 30)).term,
+    "2",
+  );
+  assert.deepEqual(getLatestEverytimeSemesterAnchor(new Date(2026, 11, 1)), {
+    year: 2027,
+    term: "1",
+    sortKey: 2027 * 4,
+  });
+});

--- a/tests/timetable/everytimeTimetable.test.ts
+++ b/tests/timetable/everytimeTimetable.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createEverytimeTimetableOverride,
+  mergeEverytimeTimetable,
+} from "../../src/utils/everytimeTimetable.ts";
+
+const snapshot = {
+  semester: "2025년 2학기",
+  weekdays: ["월", "화", "수", "목", "금"],
+  slotCount: 48,
+  courses: [
+    {
+      id: "course-1",
+      title: "원본 과목",
+      professor: "원본 교수",
+      meetings: [{ dayIndex: 0, startTime: 108, endTime: 126 }],
+    },
+  ],
+  subjects: [
+    {
+      id: "subject-1",
+      subjectId: "course-1",
+      dayIndex: 0,
+      title: "원본 과목",
+      professor: "원본 교수",
+      detail: "원본 교수 · 공학관",
+      place: "공학관",
+      color: "color1",
+      top: 450,
+      height: 75,
+    },
+  ],
+};
+
+test("새 snapshot에 사용자 override를 병합하고 원본은 변경하지 않는다", () => {
+  const override = createEverytimeTimetableOverride(
+    "everytime:2025년 2학기",
+    {
+      courseOverrides: {
+        "course-1": { title: "사용자 과목명", professor: "사용자 교수명" },
+      },
+      subjectOverrides: {
+        "subject-1": { place: "사용자 강의실", color: "color8" },
+      },
+    },
+    "2026-08-05T00:00:00.000Z",
+  );
+
+  const nextSnapshot = {
+    ...snapshot,
+    subjects: snapshot.subjects.map((subject) => ({
+      ...subject,
+      timeText: "월 09:00-10:30",
+    })),
+  };
+  const merged = mergeEverytimeTimetable(nextSnapshot, override);
+
+  assert.deepEqual(merged.subjects[0], {
+    ...nextSnapshot.subjects[0],
+    internalId: undefined,
+    title: "사용자 과목명",
+    professor: "사용자 교수명",
+    place: "사용자 강의실",
+    detail: "사용자 교수명 · 사용자 강의실",
+    color: "color8",
+  });
+  assert.equal(snapshot.subjects[0].title, "원본 과목");
+  assert.equal(merged.subjects[0].timeText, "월 09:00-10:30");
+});

--- a/tests/timetable/everytimeTimetableParsing.test.ts
+++ b/tests/timetable/everytimeTimetableParsing.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { isPrimaryEverytimeTable } from "../../src/utils/everytimeTimetableParsing.ts";
+
+function readAttribute(attributes: string, name: string): string | null {
+  return attributes.match(new RegExp(`${name}="([^"]*)"`))?.[1] ?? null;
+}
+
+test("legacy primary와 current is_primary 속성을 모두 인식한다", async () => {
+  const fixture = await readFile(
+    new URL("../fixtures/everytime-table-list.xml", import.meta.url),
+    "utf8",
+  );
+  const tables = [...fixture.matchAll(/<table\b([^>]*)\/>/g)].map(
+    (match) => match[1],
+  );
+  const primaryIds = tables
+    .filter((attributes) =>
+      isPrimaryEverytimeTable(
+        readAttribute(attributes, "primary"),
+        readAttribute(attributes, "is_primary"),
+      ),
+    )
+    .map((attributes) => readAttribute(attributes, "id"));
+
+  assert.deepEqual(primaryIds, ["primary-legacy", "primary-current"]);
+  assert.equal(isPrimaryEverytimeTable("0", "0"), false);
+  assert.equal(isPrimaryEverytimeTable(null, null), false);
+});
+
+test("DOM fallback fixture는 현재 7요일 단일 행 좌표계를 보존한다", async () => {
+  const fixture = await readFile(
+    new URL("../fixtures/everytime-timetable.html", import.meta.url),
+    "utf8",
+  );
+
+  assert.equal((fixture.match(/<td[> ]/g) ?? []).length, 7);
+  assert.match(fixture, /top:\s*450px/);
+  assert.match(fixture, /height:\s*75px/);
+});

--- a/tests/timetable/timetableImage.test.ts
+++ b/tests/timetable/timetableImage.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectImageMimeType,
+  TIMETABLE_IMAGE_REQUIREMENTS,
+} from "../../src/components/Tabs/TimeTable/timetableImage.ts";
+
+test("파일 확장자가 아닌 이미지 시그니처로 형식을 판별한다", () => {
+  assert.equal(
+    detectImageMimeType(Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10])),
+    "image/png",
+  );
+  assert.equal(
+    detectImageMimeType(Uint8Array.from([255, 216, 255, 224])),
+    "image/jpeg",
+  );
+  assert.equal(
+    detectImageMimeType(
+      Uint8Array.from([82, 73, 70, 70, 0, 0, 0, 0, 87, 69, 66, 80]),
+    ),
+    "image/webp",
+  );
+  assert.equal(
+    detectImageMimeType(
+      Uint8Array.from([0, 0, 0, 24, 102, 116, 121, 112, 97, 118, 105, 102]),
+    ),
+    "image/avif",
+  );
+  assert.equal(detectImageMimeType(Uint8Array.from([1, 2, 3, 4])), null);
+});
+
+test("압축 크기와 디코딩 해상도 제한을 함께 둔다", () => {
+  assert.equal(TIMETABLE_IMAGE_REQUIREMENTS.maxByteSize, 5 * 1024 * 1024);
+  assert.equal(TIMETABLE_IMAGE_REQUIREMENTS.maxWidth, 8_192);
+  assert.equal(TIMETABLE_IMAGE_REQUIREMENTS.maxHeight, 8_192);
+  assert.equal(TIMETABLE_IMAGE_REQUIREMENTS.maxPixelCount, 32_000_000);
+});

--- a/tests/timetable/timetableStorageSchema.test.ts
+++ b/tests/timetable/timetableStorageSchema.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createEmptyTimetableAssetIndex,
+  replaceTimetableAsset,
+  resolveTimetableAssetIndex,
+} from "../../src/utils/timetableStorageSchema.ts";
+
+const NOW = "2026-08-05T00:00:00.000Z";
+
+function createUpload(id: string, checksum = id) {
+  return {
+    schemaVersion: 3 as const,
+    id,
+    source: "upload" as const,
+    mimeType: "image/png" as const,
+    width: 1200,
+    height: 800,
+    byteSize: 1024,
+    checksum,
+    syncStatus: "local" as const,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+test("서로 다른 업로드 이미지를 collection에 보존하고 같은 ID만 교체한다", () => {
+  const first = createUpload("upload:first");
+  const second = createUpload("upload:second");
+  const updatedFirst = createUpload("upload:first", "changed");
+
+  const withFirst = replaceTimetableAsset(
+    createEmptyTimetableAssetIndex(),
+    first,
+    true,
+  );
+  const withSecond = replaceTimetableAsset(withFirst, second, true);
+  const updated = replaceTimetableAsset(withSecond, updatedFirst, false);
+
+  assert.equal(withSecond.activeAssetId, second.id);
+  assert.deepEqual(
+    updated.assets.map((asset) => asset.id),
+    [first.id, second.id],
+  );
+  assert.equal(updated.assets[0].source === "upload" && updated.assets[0].checksum, "changed");
+});
+
+test("schema v2 에브리타임 timetable을 v3 snapshot으로 이관한다", () => {
+  const resolution = resolveTimetableAssetIndex({
+    schemaVersion: 2,
+    activeAssetId: "everytime:2025년 2학기",
+    assets: [
+      {
+        schemaVersion: 2,
+        id: "everytime:2025년 2학기",
+        source: "everytime",
+        semester: "2025년 2학기",
+        timetable: {
+          semester: "2025년 2학기",
+          weekdays: ["월", "화", "수", "목", "금"],
+          slotCount: 48,
+          subjects: [],
+        },
+        checksum: "snapshot-checksum",
+        syncStatus: "local",
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ],
+  });
+
+  assert.equal(resolution.shouldPersist, true);
+  assert.equal(resolution.index.schemaVersion, 3);
+  const asset = resolution.index.assets[0];
+  assert.equal(asset.source, "everytime");
+  assert.equal(
+    asset.source === "everytime" && asset.snapshot.semester,
+    "2025년 2학기",
+  );
+});
+
+test("legacy 단일 이미지 메타를 이관하고 손상된 v3 index는 비운다", () => {
+  const migrated = resolveTimetableAssetIndex(undefined, {
+    id: "legacy",
+    source: "upload",
+    mimeType: "image/png",
+    width: 1200,
+    height: 800,
+    byteSize: 1024,
+    checksum: "legacy",
+    syncStatus: "local",
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+  assert.equal(migrated.index.assets[0]?.source, "upload");
+  assert.equal(migrated.shouldRemoveLegacyMeta, true);
+
+  const corrupted = resolveTimetableAssetIndex({
+    schemaVersion: 3,
+    activeAssetId: "broken",
+    assets: [{ id: "broken" }],
+  });
+  assert.deepEqual(corrupted.index, createEmptyTimetableAssetIndex());
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,11 @@ export default defineConfig(({ mode }) => {
               main: path.resolve(__dirname, "index.html"),
               // Background service worker entry point
               "background/index": path.resolve(__dirname, "src/background/index.ts"),
+              // Everytime timetable capture content script
+              "content/everytime-timetable": path.resolve(
+                __dirname,
+                "src/content/everytime-timetable.ts",
+              ),
             }
           : undefined,
         output: {


### PR DESCRIPTION
## Summary

- Import structured timetable data from a logged-in Everytime timetable tab through a narrowly scoped content script and background worker.
- Start from the latest four begun semesters, skip empty semesters, continue through older four-semester batches when necessary, and append older semesters on demand.
- Keep Everytime snapshots separate from user overrides so manual synchronization refreshes source data without deleting local edits, older semesters, or uploaded timetable images.
- Add the compound-component timetable UI with semester selection, manual sync, PNG/JPG/JPEG/WebP/GIF/AVIF image upload, pastel schedule cards, time labels, overflow tooltips, and the official Everytime symbol.
- Preserve multiple uploaded images, deduplicate identical files by checksum, and limit uploads to 5MB with signature, decoded-size, and resolution validation.
- Document the runtime, storage boundary, manual verification flow, and compound-component convention.

## Review follow-up

- Accept both `primary="1"` and `is_primary="1"` when selecting the representative Everytime table.
- Serialize popup/background timetable index mutations with Web Locks, with an in-context queue fallback and IndexedDB compensation when metadata persistence fails.
- Keep a foreground login tab open after sign-in, close only untouched temporary tabs, and preserve the original import mode while login resumes.
- Cover the December winter-semester boundary, API timeouts/XML error responses, cached semester metadata, missing runtime responses, and strict message-mode validation.
- Add weekday/time context for assistive technology, stable weekday keys, visible invalid-day feedback, passive tooltip scroll handling, and effect-owned object URL cleanup.
- Add fixture-backed Node tests for semester boundaries, primary attributes, DOM coordinates, override merging, image signatures/limits, multi-image collection behavior, and schema v1/v2/v3 migration.

## Security and permissions

- The content script is limited to `https://everytime.kr/timetable*`.
- LinKU uses the browser's existing Everytime session but never reads or stores passwords, cookies, or session tokens.
- Structured timetable metadata stays in `chrome.storage.local`; directly uploaded image blobs stay in IndexedDB.
- Extension local storage access is restricted to trusted extension contexts. No new broad host permission was added.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run test:timetable` (10 tests)
- `pnpm run lint`
- `pnpm run build:local`
- `git diff --check`
- Logged-in Chrome DOM validation confirmed the selected `2025년 2학기`, 68 semester options, seven weekday cells, and 24 grid rows in the first weekday cell.
- Popup-size browser validation covered the timetable empty state, official Everytime action, disabled academic-system action, and image upload entry point.
- Generated PNG, JPEG, WebP, GIF, and AVIF signatures are covered by the regression suite. Chrome file chooser injection remains a manual reviewer step because the browser-control extension does not have file-URL access.
- The build was written to the shared unpacked-extension `dist/` path. Chrome blocks automated access to `chrome://extensions`, so the final extension reload remains a manual reviewer step.

## Build notes

The build succeeds with the repository's existing Vite native-config `__dirname` notice and the existing large-chunk warning.
