### PR TITLE
feat(voc): add reliable feedback flow

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -30,3 +30,6 @@ VITE_GA_API_SECRET=your_api_secret_here
 
 # 우리 Backend 주소
 VITE_API_BASE_URL=https://this-is-linku-backend.example/api
+
+# VoC Google Apps Script Web App의 /exec URL
+VITE_VOC_ENDPOINT=https://script.google.com/macros/s/your_deployment_id/exec

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Build for GitHub Pages
         env:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_VOC_ENDPOINT: ${{ vars.VITE_VOC_ENDPOINT }}
         run: pnpm run build:gh-pages
 
       - name: Deploy to gh-pages branch

--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Build project
         env:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_VOC_ENDPOINT: ${{ vars.VITE_VOC_ENDPOINT }}
         run: pnpm run build:local
 
       - name: Build success

--- a/.github/workflows/upload-chrome-extension-draft.yml
+++ b/.github/workflows/upload-chrome-extension-draft.yml
@@ -67,6 +67,7 @@ jobs:
         env:
           VITE_GA_API_SECRET: ${{ secrets.VITE_GA_API_SECRET }}
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_VOC_ENDPOINT: ${{ vars.VITE_VOC_ENDPOINT }}
         run: tsc -b && pnpm exec vite build --mode production && pnpm run check:content-scripts
 
       - name: Create dist.zip

--- a/docs/GA4-Data-Taxonomy.md
+++ b/docs/GA4-Data-Taxonomy.md
@@ -59,8 +59,9 @@
 | --- | --- | --- | --- |
 | `screen_name` | string | 현재 화면/페이지 | `popup_home`, `template_editor` |
 | `entry_point` | string | 진입 경로 | `popup`, `settings_dialog`, `gallery_page` |
-| `feature_area` | string | 상위 기능 영역 | `links`, `templates`, `alerts`, `todo`, `labs`, `auth` |
+| `feature_area` | string | 상위 기능 영역 | `links`, `templates`, `alerts`, `todo`, `labs`, `settings`, `auth` |
 | `ui_location` | string | UI 내 위치 | `header`, `tab_bar`, `card_action`, `dialog` |
+| `view_source` | string | 화면이 표시된 경로 | `default`, `restored`, `user_select` |
 | `template_id` | number | 템플릿 식별자 | `12345` |
 | `template_origin` | string | 템플릿 출처 | `default`, `owned`, `cloned`, `posted`, `local_only` |
 | `result` | string | 성공/실패/취소 | `success`, `fail`, `cancel` |
@@ -91,6 +92,7 @@ LinKU의 가장 기본 가치인 "교내외 링크를 빠르게 연다"를 측�
 | Event Name | 상태 | 목적 | 주요 Params | 비고 |
 | --- | --- | --- | --- | --- |
 | `navigation_tab_select` | 구현됨 | 어떤 탭이 실제로 사용되는지 | `tab_name`, `feature_area?` | `ui_location`은 미전송 |
+| `navigation_tab_view` | 구현됨 | 다이얼로그 탭의 실제 노출 | `tab_name`, `feature_area`, `ui_location`, `view_source` | 복원과 사용자 선택을 구분 |
 | `search_submit` | 구현됨 | 검색 기능 사용률 측정 | `search_term`, `search_location?` | |
 | `link_open` | 구현됨 | LinKU 핵심 가치 행동 | `link_name`, `link_url`, `link_group?`, `same_host_variant?` | same-host 버튼은 `samehost_primary` / `samehost_secondary`로 구분 |
 | `banner_open` | 구현됨 | 배너 클릭 효율 측정 | `banner_id`, `banner_title`, `banner_position` | |
@@ -262,13 +264,14 @@ LinKU의 가장 기본 가치인 "교내외 링크를 빠르게 연다"를 측�
 | `setting_change` | 계정 정보 변경 | eCampus 자격증명 변경 파악 (레거시) | `setting_name`, `setting_value` | `SettingsDialog.tsx` 내부 병렬 발송 | MP_settingsCredentials_* 와 동시 발화 |
 | `tab_change` | 탭 선택 | 탭 사용 패턴 파악 | `tab_name`, `feature_area?` | `TabsLayout.tsx · handleTabChange` | - |
 
-### 신규 이벤트 (택소노미 정립 후, MP_ prefix)
+### 신규 이벤트 (택소노미 정립 후)
 
 | 이벤트명 | 항목 | 수집 목적 | 수집 속성 | 사용 코드 | 비고 |
 | --- | --- | --- | --- | --- | --- |
 | `extension_first_open` | 최초 실행 | 첫 사용 cohort 정의 | `screen_name`, `entry_point` | `App.tsx · sendExtensionOpen` 내부 자동 처리 | `firstOpenSent` 플래그로 기기당 1회 보장 |
 | `extension_open` | 팝업 열기 | 실제 사용 시작 기록 | `screen_name`, `entry_point` | `App.tsx · useEffect → sendExtensionOpen` | - |
 | `extension_session_start` | 세션 시작 | 세션 기준 정의 | `screen_name`, `entry_point` | `App.tsx · sendExtensionOpen` 내부 자동 처리 | 30분 inactivity 초과 시에만 전송 |
+| `navigation_tab_view` | 다이얼로그 탭 노출 | 실제로 표시된 실험실·설정 탭 측정 | `feature_area`, `tab_name`, `ui_location`, `view_source` | `usePersistentDialogTab.ts` | 기본값·복원·사용자 선택을 구분 |
 | `MP_alerts_view` | 공지 탭 진입 | 공지 탭 사용 여부 | `view_mode`, `category` | `Alerts.tsx · initialize()` | - |
 | `MP_alertsItem_open` | 공지 클릭 | 공지 클릭률 측정 | `alert_id`, `category`, `source` | `AlertItem.tsx · handleClick` | - |
 | `MP_alertsSubscription_update` | 구독 변경 | 학과 구독 변경 파악 | `category`, `subscription_result`(`subscribe`\|`unsubscribe`) | `SubscriptionManager.tsx · handleSubscribe`, `handleUnsubscribe` | - |

--- a/integrations/apps-script-voc/Code.gs
+++ b/integrations/apps-script-voc/Code.gs
@@ -27,13 +27,16 @@ const VOC_HEADERS = Object.freeze([
   "notification_sent",
   "notification_attempts",
   "last_notification_error",
+  "contact_email",
 ]);
+
+const LEGACY_VOC_HEADERS = Object.freeze(VOC_HEADERS.slice(0, -1));
 
 const VOC_CATEGORY_LABELS = Object.freeze({
   feature: "기능 제안",
   bug: "오류 제보",
   experience: "사용 경험",
-  other: "기타 의견",
+  other: "의견",
 });
 
 /**
@@ -117,10 +120,17 @@ function doPost(event) {
     const existingRow = findSubmissionRow_(sheet, submission.submissionId);
     const duplicate = existingRow !== null;
     if (duplicate) {
+      const contactEmailStored = ensureContactEmail_(
+        sheet,
+        existingRow,
+        submission.contactEmail,
+      );
+      SpreadsheetApp.flush();
       return jsonResponse_({
         success: true,
         persisted: true,
         duplicate: true,
+        contactEmailStored: contactEmailStored,
       });
     }
 
@@ -134,6 +144,7 @@ function doPost(event) {
       success: true,
       persisted: true,
       duplicate: false,
+      contactEmailStored: true,
     });
   } catch (error) {
     const errorCode = getErrorCode_(error);
@@ -262,6 +273,7 @@ function parseSubmission_(event) {
   const category = normalizeText_(payload.category);
   const title = normalizeText_(payload.title).trim();
   const message = normalizeText_(payload.message).trim();
+  const contactEmail = normalizeText_(payload.contactEmail).trim().toLowerCase();
   const extensionVersion = normalizeText_(payload.extensionVersion).trim();
   const createdAt = normalizeText_(payload.createdAt).trim();
   const website = normalizeText_(payload.website).trim();
@@ -269,10 +281,11 @@ function parseSubmission_(event) {
   const valid =
     /^[A-Za-z0-9-]{20,64}$/.test(submissionId) &&
     Object.prototype.hasOwnProperty.call(VOC_CATEGORY_LABELS, category) &&
-    title.length >= 2 &&
+    title.length >= 1 &&
     title.length <= 80 &&
-    message.length >= 10 &&
+    message.length >= 1 &&
     message.length <= 500 &&
+    (contactEmail === "" || isValidContactEmail_(contactEmail)) &&
     extensionVersion.length >= 1 &&
     extensionVersion.length <= 32 &&
     !Number.isNaN(Date.parse(createdAt)) &&
@@ -285,9 +298,16 @@ function parseSubmission_(event) {
     category: category,
     title: title,
     message: message,
+    contactEmail: contactEmail,
     extensionVersion: extensionVersion,
     createdAt: createdAt,
   };
+}
+
+function isValidContactEmail_(email) {
+  return (
+    email.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  );
 }
 
 function getConfiguredSpreadsheet_() {
@@ -317,7 +337,22 @@ function getOrCreateFeedbackSheet_(spreadsheet) {
       .getRange(1, 1, 1, VOC_HEADERS.length)
       .getDisplayValues()[0];
     if (existingHeaders.join("\u0000") !== VOC_HEADERS.join("\u0000")) {
-      throw new Error("INVALID_SHEET_SCHEMA");
+      const existingLegacyHeaders = existingHeaders.slice(
+        0,
+        LEGACY_VOC_HEADERS.length,
+      );
+      const contactEmailHeader = existingHeaders[LEGACY_VOC_HEADERS.length];
+      if (
+        existingLegacyHeaders.join("\u0000") ===
+          LEGACY_VOC_HEADERS.join("\u0000") &&
+        contactEmailHeader === ""
+      ) {
+        sheet
+          .getRange(1, VOC_HEADERS.length)
+          .setValue(VOC_HEADERS[VOC_HEADERS.length - 1]);
+      } else {
+        throw new Error("INVALID_SHEET_SCHEMA");
+      }
     }
   }
 
@@ -335,6 +370,27 @@ function findSubmissionRow_(sheet, submissionId) {
   return match ? match.getRow() : null;
 }
 
+function ensureContactEmail_(sheet, rowNumber, contactEmail) {
+  if (!contactEmail) return true;
+
+  const emailColumn = VOC_HEADERS.indexOf("contact_email") + 1;
+  const storedEmail = String(
+    sheet.getRange(rowNumber, emailColumn).getDisplayValue(),
+  )
+    .trim()
+    .toLowerCase();
+  if (storedEmail === contactEmail) return true;
+  if (storedEmail !== "") return false;
+
+  sheet.getRange(rowNumber, emailColumn).setValue(safeSheetText_(contactEmail));
+  const notificationSentColumn = VOC_HEADERS.indexOf("notification_sent") + 1;
+  if (sheet.getRange(rowNumber, notificationSentColumn).getValue() === true) {
+    // 이전 수집기가 이메일 없이 이미 보고한 건도 답장 주소와 함께 한 번 더 알립니다.
+    sheet.getRange(rowNumber, notificationSentColumn).setValue(false);
+  }
+  return true;
+}
+
 function appendSubmission_(sheet, submission) {
   sheet.appendRow([
     safeSheetText_(submission.submissionId),
@@ -347,12 +403,15 @@ function appendSubmission_(sheet, submission) {
     false,
     0,
     "",
+    safeSheetText_(submission.contactEmail),
   ]);
   return sheet.getLastRow();
 }
 
 function readSubmission_(sheet, rowNumber) {
-  const row = sheet.getRange(rowNumber, 1, 1, 10).getValues()[0];
+  const row = sheet
+    .getRange(rowNumber, 1, 1, VOC_HEADERS.length)
+    .getValues()[0];
   return {
     submissionId: String(row[0]),
     receivedAt: row[1],
@@ -360,6 +419,7 @@ function readSubmission_(sheet, rowNumber) {
     category: String(row[3]),
     title: String(row[4]),
     message: String(row[5]),
+    contactEmail: String(row[10] || ""),
     extensionVersion: String(row[6]),
     notificationSent: row[7] === true,
     notificationAttempts: Number(row[8]) || 0,
@@ -395,7 +455,7 @@ function buildDailyDigest_(pending, digestDate, spreadsheetUrl) {
       VOC_CONFIG.digestTimezone,
       "yyyy-MM-dd HH:mm",
     );
-    const section = [
+    const sectionLines = [
       includedItems.length +
         1 +
         ". [" +
@@ -404,9 +464,15 @@ function buildDailyDigest_(pending, digestDate, spreadsheetUrl) {
         submission.title,
       "접수: " + receivedAt,
       "내용: " + submission.message,
+    ];
+    if (submission.contactEmail) {
+      sectionLines.push("답장 이메일: " + submission.contactEmail);
+    }
+    sectionLines.push(
       "확장 프로그램 버전: " + submission.extensionVersion,
       "제출 ID: " + submission.submissionId,
-    ].join("\n");
+    );
+    const section = sectionLines.join("\n");
     const candidateBody = header
       .concat([
         "",

--- a/integrations/apps-script-voc/Code.gs
+++ b/integrations/apps-script-voc/Code.gs
@@ -4,8 +4,12 @@ const VOC_CONFIG = Object.freeze({
   sheetNameProperty: "VOC_SHEET_NAME",
   defaultSheetName: "Feedback",
   spreadsheetName: "LinKU VoC",
-  retryFunctionName: "retryPendingNotifications",
-  maxNotificationsPerRetry: 20,
+  digestFunctionName: "sendDailyDigest",
+  legacyRetryFunctionName: "retryPendingNotifications",
+  lastDigestDateProperty: "VOC_LAST_DIGEST_DATE",
+  digestHour: 9,
+  digestTimezone: "Asia/Seoul",
+  maxDigestBodyBytes: 180 * 1024,
   maxRequestsPerMinute: 10,
 });
 
@@ -31,7 +35,7 @@ const VOC_CATEGORY_LABELS = Object.freeze({
 
 /**
  * Apps Script 편집기에서 최초 1회 직접 실행합니다.
- * 전용 Spreadsheet와 메일 재시도 트리거를 만들고 Script Properties에 저장합니다.
+ * 전용 Spreadsheet와 일일 다이제스트 트리거를 만들고 Script Properties에 저장합니다.
  */
 function initialize() {
   const properties = PropertiesService.getScriptProperties();
@@ -68,7 +72,7 @@ function initialize() {
   }
 
   const sheet = getOrCreateFeedbackSheet_(spreadsheet);
-  installRetryTrigger_();
+  installDailyDigestTrigger_();
 
   // 최초 실행 시 메일 권한도 함께 승인받습니다.
   const remainingMailQuota = MailApp.getRemainingDailyQuota();
@@ -77,6 +81,8 @@ function initialize() {
     sheetName: sheet.getName(),
     recipientEmail: recipientEmail,
     remainingMailQuota: remainingMailQuota,
+    dailyDigestHour: VOC_CONFIG.digestHour,
+    dailyDigestTimezone: VOC_CONFIG.digestTimezone,
   };
 }
 
@@ -112,16 +118,9 @@ function doPost(event) {
       ? existingRow
       : appendSubmission_(sheet, submission);
 
-    // Sheet 반영을 먼저 확정한 뒤 알림을 시도합니다.
+    // Sheet 반영만 즉시 확정하고, 메일은 일일 다이제스트가 별도로 처리합니다.
     SpreadsheetApp.flush();
-    const storedSubmission = readSubmission_(sheet, rowNumber);
-    const notificationSent = attemptNotification_(
-      sheet,
-      rowNumber,
-      storedSubmission,
-      spreadsheet.getUrl(),
-    );
-    SpreadsheetApp.flush();
+    const notificationSent = readSubmission_(sheet, rowNumber).notificationSent;
 
     return jsonResponse_({
       success: true,
@@ -145,49 +144,101 @@ function doPost(event) {
 }
 
 /**
- * 메일 할당량 또는 일시 오류로 알림을 못 보낸 행을 다시 처리합니다.
- * initialize()가 6시간 간격의 시간 기반 트리거를 자동으로 등록합니다.
+ * 아직 메일로 보고되지 않은 VoC를 매일 한 통의 다이제스트로 발송합니다.
+ * initialize()가 매일 오전 9시(KST) 전후의 시간 기반 트리거를 등록합니다.
  */
-function retryPendingNotifications() {
+function sendDailyDigest() {
   const lock = LockService.getScriptLock();
-  if (!lock.tryLock(10000)) return;
+  if (!lock.tryLock(10000)) {
+    return { sent: false, reason: "BUSY" };
+  }
 
   try {
-    const spreadsheet = getConfiguredSpreadsheet_();
-    const sheet = getOrCreateFeedbackSheet_(spreadsheet);
-    const lastRow = sheet.getLastRow();
-    let attempted = 0;
-
-    for (let rowNumber = 2; rowNumber <= lastRow; rowNumber += 1) {
-      const notificationSent = sheet.getRange(rowNumber, 8).getValue() === true;
-      if (notificationSent) continue;
-      if (MailApp.getRemainingDailyQuota() < 1) break;
-      if (attempted >= VOC_CONFIG.maxNotificationsPerRetry) break;
-
-      try {
-        const submission = readSubmission_(sheet, rowNumber);
-        attemptNotification_(
-          sheet,
-          rowNumber,
-          submission,
-          spreadsheet.getUrl(),
-        );
-      } catch (error) {
-        setNotificationState_(
-          sheet,
-          rowNumber,
-          false,
-          Number(sheet.getRange(rowNumber, 9).getValue() || 0) + 1,
-          getPrivateErrorMessage_(error),
-        );
-      }
-      attempted += 1;
+    const properties = PropertiesService.getScriptProperties();
+    const digestDate = Utilities.formatDate(
+      new Date(),
+      VOC_CONFIG.digestTimezone,
+      "yyyy-MM-dd",
+    );
+    if (
+      properties.getProperty(VOC_CONFIG.lastDigestDateProperty) === digestDate
+    ) {
+      return { sent: false, reason: "ALREADY_SENT_TODAY" };
     }
 
-    SpreadsheetApp.flush();
+    const spreadsheet = getConfiguredSpreadsheet_();
+    const sheet = getOrCreateFeedbackSheet_(spreadsheet);
+    const pending = getPendingNotifications_(sheet);
+    if (pending.length === 0) {
+      return { sent: false, reason: "NO_PENDING_FEEDBACK" };
+    }
+
+    const recipientEmail = properties.getProperty(
+      VOC_CONFIG.recipientEmailProperty,
+    );
+    if (!recipientEmail) {
+      updateNotificationFailures_(
+        sheet,
+        pending,
+        "VOC_RECIPIENT_EMAIL is not configured",
+      );
+      return { sent: false, reason: "RECIPIENT_NOT_CONFIGURED" };
+    }
+
+    if (MailApp.getRemainingDailyQuota() < 1) {
+      updateNotificationFailures_(sheet, pending, "Mail quota exhausted");
+      return { sent: false, reason: "MAIL_QUOTA_EXHAUSTED" };
+    }
+
+    const digest = buildDailyDigest_(
+      pending,
+      digestDate,
+      spreadsheet.getUrl(),
+    );
+
+    try {
+      MailApp.sendEmail({
+        to: recipientEmail,
+        subject:
+          "[LinKU VoC] " + digestDate + " 의견 " + digest.items.length + "건",
+        body: digest.body,
+        name: "LinKU VoC",
+      });
+
+      for (const item of digest.items) {
+        setNotificationState_(
+          sheet,
+          item.rowNumber,
+          true,
+          item.submission.notificationAttempts + 1,
+          "",
+        );
+      }
+      properties.setProperty(VOC_CONFIG.lastDigestDateProperty, digestDate);
+      SpreadsheetApp.flush();
+      return {
+        sent: true,
+        includedCount: digest.items.length,
+        deferredCount: pending.length - digest.items.length,
+      };
+    } catch (error) {
+      updateNotificationFailures_(
+        sheet,
+        digest.items,
+        getPrivateErrorMessage_(error),
+      );
+      return { sent: false, reason: "MAIL_SEND_FAILED" };
+    }
   } finally {
     lock.releaseLock();
   }
+}
+
+/**
+ * 기존 6시간 트리거가 남아 있어도 하루 한 번만 발송되도록 하는 migration alias.
+ */
+function retryPendingNotifications() {
+  return sendDailyDigest();
 }
 
 function parseSubmission_(event) {
@@ -319,80 +370,95 @@ function readSubmission_(sheet, rowNumber) {
   };
 }
 
-function attemptNotification_(
-  sheet,
-  rowNumber,
-  submission,
-  spreadsheetUrl,
-) {
-  if (submission.notificationSent) return true;
-
-  const attempts = submission.notificationAttempts + 1;
-  try {
-    const recipientEmail = PropertiesService.getScriptProperties().getProperty(
-      VOC_CONFIG.recipientEmailProperty,
-    );
-
-    if (!recipientEmail) {
-      setNotificationState_(
-        sheet,
-        rowNumber,
-        false,
-        attempts,
-        "VOC_RECIPIENT_EMAIL is not configured",
-      );
-      return false;
+function getPendingNotifications_(sheet) {
+  const pending = [];
+  for (let rowNumber = 2; rowNumber <= sheet.getLastRow(); rowNumber += 1) {
+    const submission = readSubmission_(sheet, rowNumber);
+    if (!submission.notificationSent) {
+      pending.push({ rowNumber: rowNumber, submission: submission });
     }
+  }
+  return pending;
+}
 
-    if (MailApp.getRemainingDailyQuota() < 1) {
-      setNotificationState_(
-        sheet,
-        rowNumber,
-        false,
-        attempts,
-        "Mail quota exhausted",
-      );
-      return false;
-    }
+function buildDailyDigest_(pending, digestDate, spreadsheetUrl) {
+  const header = [
+    digestDate + " LinKU VoC 다이제스트",
+    "",
+    "메일로 보고되지 않은 의견 " + pending.length + "건을 모았습니다.",
+  ];
+  const sections = [];
+  const includedItems = [];
 
+  for (const item of pending) {
+    const submission = item.submission;
     const categoryLabel =
       VOC_CATEGORY_LABELS[submission.category] || VOC_CATEGORY_LABELS.other;
-    const subjectTitle = submission.title.replace(/[\r\n]+/g, " ");
-    const body = [
-      "LinKU에 새로운 의견이 도착했습니다.",
-      "",
-      "유형: " + categoryLabel,
-      "제목: " + submission.title,
-      "내용:",
-      submission.message,
-      "",
+    const receivedAt = Utilities.formatDate(
+      new Date(submission.receivedAt),
+      VOC_CONFIG.digestTimezone,
+      "yyyy-MM-dd HH:mm",
+    );
+    const section = [
+      includedItems.length +
+        1 +
+        ". [" +
+        categoryLabel +
+        "] " +
+        submission.title,
+      "접수: " + receivedAt,
+      "내용: " + submission.message,
       "확장 프로그램 버전: " + submission.extensionVersion,
       "제출 ID: " + submission.submissionId,
-      "Sheet: " + spreadsheetUrl,
     ].join("\n");
+    const candidateBody = header
+      .concat([
+        "",
+        sections.concat([section]).join("\n\n"),
+        "",
+        "Sheet: " + spreadsheetUrl,
+      ])
+      .join("\n");
 
-    MailApp.sendEmail({
-      to: recipientEmail,
-      subject: "[LinKU VoC/" + categoryLabel + "] " + subjectTitle,
-      body: body,
-      name: "LinKU VoC",
-    });
-    setNotificationState_(sheet, rowNumber, true, attempts, "");
-    return true;
-  } catch (error) {
-    try {
-      setNotificationState_(
-        sheet,
-        rowNumber,
-        false,
-        attempts,
-        getPrivateErrorMessage_(error),
-      );
-    } catch (_stateError) {
-      // Sheet 본문은 이미 저장됐으므로 알림 상태 기록 실패도 제출 실패로 바꾸지 않습니다.
+    if (getUtf8ByteLength_(candidateBody) > VOC_CONFIG.maxDigestBodyBytes) {
+      break;
     }
-    return false;
+    sections.push(section);
+    includedItems.push(item);
   }
+
+  const deferredCount = pending.length - includedItems.length;
+  const footer = [
+    "",
+    deferredCount > 0
+      ? "메일 크기 제한으로 나머지 " +
+        deferredCount +
+        "건은 Sheet에서 확인하거나 다음 다이제스트에서 받을 수 있습니다."
+      : "모든 미보고 의견을 포함했습니다.",
+    "Sheet: " + spreadsheetUrl,
+  ];
+
+  return {
+    body: header.concat(["", sections.join("\n\n")], footer).join("\n"),
+    items: includedItems,
+  };
+}
+
+function getUtf8ByteLength_(text) {
+  return Utilities.newBlob(text).getBytes().length;
+}
+
+function updateNotificationFailures_(sheet, items, error) {
+  for (const item of items) {
+    setNotificationState_(
+      sheet,
+      item.rowNumber,
+      false,
+      item.submission.notificationAttempts + 1,
+      error,
+    );
+  }
+  SpreadsheetApp.flush();
 }
 
 function setNotificationState_(sheet, rowNumber, sent, attempts, error) {
@@ -401,17 +467,26 @@ function setNotificationState_(sheet, rowNumber, sent, attempts, error) {
     .setValues([[sent, attempts, safeSheetText_(error).slice(0, 200)]]);
 }
 
-function installRetryTrigger_() {
-  const alreadyInstalled = ScriptApp.getProjectTriggers().some(
-    (trigger) =>
-      trigger.getHandlerFunction() === VOC_CONFIG.retryFunctionName &&
-      trigger.getEventType() === ScriptApp.EventType.CLOCK,
-  );
-  if (alreadyInstalled) return;
+function installDailyDigestTrigger_() {
+  const managedHandlers = [
+    VOC_CONFIG.digestFunctionName,
+    VOC_CONFIG.legacyRetryFunctionName,
+  ];
+  for (const trigger of ScriptApp.getProjectTriggers()) {
+    if (
+      trigger.getEventType() === ScriptApp.EventType.CLOCK &&
+      managedHandlers.includes(trigger.getHandlerFunction())
+    ) {
+      ScriptApp.deleteTrigger(trigger);
+    }
+  }
 
-  ScriptApp.newTrigger(VOC_CONFIG.retryFunctionName)
+  ScriptApp.newTrigger(VOC_CONFIG.digestFunctionName)
     .timeBased()
-    .everyHours(6)
+    .atHour(VOC_CONFIG.digestHour)
+    .nearMinute(0)
+    .everyDays(1)
+    .inTimezone(VOC_CONFIG.digestTimezone)
     .create();
 }
 

--- a/integrations/apps-script-voc/Code.gs
+++ b/integrations/apps-script-voc/Code.gs
@@ -1,0 +1,464 @@
+const VOC_CONFIG = Object.freeze({
+  spreadsheetIdProperty: "VOC_SPREADSHEET_ID",
+  recipientEmailProperty: "VOC_RECIPIENT_EMAIL",
+  sheetNameProperty: "VOC_SHEET_NAME",
+  defaultSheetName: "Feedback",
+  spreadsheetName: "LinKU VoC",
+  retryFunctionName: "retryPendingNotifications",
+  maxNotificationsPerRetry: 20,
+  maxRequestsPerMinute: 10,
+});
+
+const VOC_HEADERS = Object.freeze([
+  "submission_id",
+  "received_at",
+  "created_at",
+  "category",
+  "title",
+  "message",
+  "extension_version",
+  "notification_sent",
+  "notification_attempts",
+  "last_notification_error",
+]);
+
+const VOC_CATEGORY_LABELS = Object.freeze({
+  feature: "기능 제안",
+  bug: "오류 제보",
+  experience: "사용 경험",
+  other: "기타 의견",
+});
+
+/**
+ * Apps Script 편집기에서 최초 1회 직접 실행합니다.
+ * 전용 Spreadsheet와 메일 재시도 트리거를 만들고 Script Properties에 저장합니다.
+ */
+function initialize() {
+  const properties = PropertiesService.getScriptProperties();
+  let spreadsheetId = properties.getProperty(
+    VOC_CONFIG.spreadsheetIdProperty,
+  );
+  let spreadsheet;
+
+  if (spreadsheetId) {
+    spreadsheet = SpreadsheetApp.openById(spreadsheetId);
+  } else {
+    spreadsheet = SpreadsheetApp.create(VOC_CONFIG.spreadsheetName);
+    spreadsheetId = spreadsheet.getId();
+    properties.setProperty(
+      VOC_CONFIG.spreadsheetIdProperty,
+      spreadsheetId,
+    );
+  }
+
+  let recipientEmail = properties.getProperty(
+    VOC_CONFIG.recipientEmailProperty,
+  );
+  if (!recipientEmail) {
+    recipientEmail = Session.getEffectiveUser().getEmail();
+    if (!recipientEmail) {
+      throw new Error(
+        "프로젝트 설정의 Script Properties에 VOC_RECIPIENT_EMAIL을 추가하세요.",
+      );
+    }
+    properties.setProperty(
+      VOC_CONFIG.recipientEmailProperty,
+      recipientEmail,
+    );
+  }
+
+  const sheet = getOrCreateFeedbackSheet_(spreadsheet);
+  installRetryTrigger_();
+
+  // 최초 실행 시 메일 권한도 함께 승인받습니다.
+  const remainingMailQuota = MailApp.getRemainingDailyQuota();
+  return {
+    spreadsheetUrl: spreadsheet.getUrl(),
+    sheetName: sheet.getName(),
+    recipientEmail: recipientEmail,
+    remainingMailQuota: remainingMailQuota,
+  };
+}
+
+function doGet() {
+  return jsonResponse_({
+    success: true,
+    service: "linku-voc",
+  });
+}
+
+function doPost(event) {
+  let lock;
+
+  try {
+    const submission = parseSubmission_(event);
+    enforceRateLimit_(submission.clientId);
+
+    lock = LockService.getScriptLock();
+    if (!lock.tryLock(10000)) {
+      return jsonResponse_({
+        success: false,
+        persisted: false,
+        retryable: true,
+        error: "BUSY",
+      });
+    }
+
+    const spreadsheet = getConfiguredSpreadsheet_();
+    const sheet = getOrCreateFeedbackSheet_(spreadsheet);
+    const existingRow = findSubmissionRow_(sheet, submission.submissionId);
+    const duplicate = existingRow !== null;
+    const rowNumber = duplicate
+      ? existingRow
+      : appendSubmission_(sheet, submission);
+
+    // Sheet 반영을 먼저 확정한 뒤 알림을 시도합니다.
+    SpreadsheetApp.flush();
+    const storedSubmission = readSubmission_(sheet, rowNumber);
+    const notificationSent = attemptNotification_(
+      sheet,
+      rowNumber,
+      storedSubmission,
+      spreadsheet.getUrl(),
+    );
+    SpreadsheetApp.flush();
+
+    return jsonResponse_({
+      success: true,
+      persisted: true,
+      duplicate: duplicate,
+      notificationSent: notificationSent,
+    });
+  } catch (error) {
+    const errorCode = getErrorCode_(error);
+    return jsonResponse_({
+      success: false,
+      persisted: false,
+      retryable: errorCode !== "INVALID_PAYLOAD",
+      error: errorCode,
+    });
+  } finally {
+    if (lock && lock.hasLock()) {
+      lock.releaseLock();
+    }
+  }
+}
+
+/**
+ * 메일 할당량 또는 일시 오류로 알림을 못 보낸 행을 다시 처리합니다.
+ * initialize()가 6시간 간격의 시간 기반 트리거를 자동으로 등록합니다.
+ */
+function retryPendingNotifications() {
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(10000)) return;
+
+  try {
+    const spreadsheet = getConfiguredSpreadsheet_();
+    const sheet = getOrCreateFeedbackSheet_(spreadsheet);
+    const lastRow = sheet.getLastRow();
+    let attempted = 0;
+
+    for (let rowNumber = 2; rowNumber <= lastRow; rowNumber += 1) {
+      const notificationSent = sheet.getRange(rowNumber, 8).getValue() === true;
+      if (notificationSent) continue;
+      if (MailApp.getRemainingDailyQuota() < 1) break;
+      if (attempted >= VOC_CONFIG.maxNotificationsPerRetry) break;
+
+      try {
+        const submission = readSubmission_(sheet, rowNumber);
+        attemptNotification_(
+          sheet,
+          rowNumber,
+          submission,
+          spreadsheet.getUrl(),
+        );
+      } catch (error) {
+        setNotificationState_(
+          sheet,
+          rowNumber,
+          false,
+          Number(sheet.getRange(rowNumber, 9).getValue() || 0) + 1,
+          getPrivateErrorMessage_(error),
+        );
+      }
+      attempted += 1;
+    }
+
+    SpreadsheetApp.flush();
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function parseSubmission_(event) {
+  const contents =
+    event && event.postData && typeof event.postData.contents === "string"
+      ? event.postData.contents
+      : "";
+
+  if (!contents || contents.length > 5000) {
+    throw new Error("INVALID_PAYLOAD");
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(contents);
+  } catch (_error) {
+    throw new Error("INVALID_PAYLOAD");
+  }
+
+  const submissionId = normalizeText_(payload.submissionId);
+  const clientId = normalizeText_(payload.clientId);
+  const category = normalizeText_(payload.category);
+  const title = normalizeText_(payload.title).trim();
+  const message = normalizeText_(payload.message).trim();
+  const extensionVersion = normalizeText_(payload.extensionVersion).trim();
+  const createdAt = normalizeText_(payload.createdAt).trim();
+  const website = normalizeText_(payload.website).trim();
+
+  const valid =
+    /^[A-Za-z0-9-]{20,64}$/.test(submissionId) &&
+    clientId.length >= 8 &&
+    clientId.length <= 128 &&
+    Object.prototype.hasOwnProperty.call(VOC_CATEGORY_LABELS, category) &&
+    title.length >= 2 &&
+    title.length <= 80 &&
+    message.length >= 10 &&
+    message.length <= 500 &&
+    extensionVersion.length >= 1 &&
+    extensionVersion.length <= 32 &&
+    !Number.isNaN(Date.parse(createdAt)) &&
+    website === "";
+
+  if (!valid) throw new Error("INVALID_PAYLOAD");
+
+  return {
+    submissionId: submissionId,
+    clientId: clientId,
+    category: category,
+    title: title,
+    message: message,
+    extensionVersion: extensionVersion,
+    createdAt: createdAt,
+  };
+}
+
+function getConfiguredSpreadsheet_() {
+  const spreadsheetId = PropertiesService.getScriptProperties().getProperty(
+    VOC_CONFIG.spreadsheetIdProperty,
+  );
+  if (!spreadsheetId) throw new Error("NOT_CONFIGURED");
+  return SpreadsheetApp.openById(spreadsheetId);
+}
+
+function getOrCreateFeedbackSheet_(spreadsheet) {
+  const properties = PropertiesService.getScriptProperties();
+  const sheetName =
+    properties.getProperty(VOC_CONFIG.sheetNameProperty) ||
+    VOC_CONFIG.defaultSheetName;
+  let sheet = spreadsheet.getSheetByName(sheetName);
+
+  if (!sheet) {
+    sheet = spreadsheet.insertSheet(sheetName);
+  }
+
+  if (sheet.getLastRow() === 0) {
+    sheet.getRange(1, 1, 1, VOC_HEADERS.length).setValues([VOC_HEADERS]);
+    sheet.setFrozenRows(1);
+  } else {
+    const existingHeaders = sheet
+      .getRange(1, 1, 1, VOC_HEADERS.length)
+      .getDisplayValues()[0];
+    if (existingHeaders.join("\u0000") !== VOC_HEADERS.join("\u0000")) {
+      throw new Error("INVALID_SHEET_SCHEMA");
+    }
+  }
+
+  return sheet;
+}
+
+function findSubmissionRow_(sheet, submissionId) {
+  if (sheet.getLastRow() < 2) return null;
+
+  const match = sheet
+    .getRange(2, 1, sheet.getLastRow() - 1, 1)
+    .createTextFinder(submissionId)
+    .matchEntireCell(true)
+    .findNext();
+  return match ? match.getRow() : null;
+}
+
+function appendSubmission_(sheet, submission) {
+  sheet.appendRow([
+    safeSheetText_(submission.submissionId),
+    new Date(),
+    new Date(submission.createdAt),
+    safeSheetText_(submission.category),
+    safeSheetText_(submission.title),
+    safeSheetText_(submission.message),
+    safeSheetText_(submission.extensionVersion),
+    false,
+    0,
+    "",
+  ]);
+  return sheet.getLastRow();
+}
+
+function readSubmission_(sheet, rowNumber) {
+  const row = sheet.getRange(rowNumber, 1, 1, 10).getValues()[0];
+  return {
+    submissionId: String(row[0]),
+    receivedAt: row[1],
+    createdAt: row[2],
+    category: String(row[3]),
+    title: String(row[4]),
+    message: String(row[5]),
+    extensionVersion: String(row[6]),
+    notificationSent: row[7] === true,
+    notificationAttempts: Number(row[8]) || 0,
+  };
+}
+
+function attemptNotification_(
+  sheet,
+  rowNumber,
+  submission,
+  spreadsheetUrl,
+) {
+  if (submission.notificationSent) return true;
+
+  const attempts = submission.notificationAttempts + 1;
+  try {
+    const recipientEmail = PropertiesService.getScriptProperties().getProperty(
+      VOC_CONFIG.recipientEmailProperty,
+    );
+
+    if (!recipientEmail) {
+      setNotificationState_(
+        sheet,
+        rowNumber,
+        false,
+        attempts,
+        "VOC_RECIPIENT_EMAIL is not configured",
+      );
+      return false;
+    }
+
+    if (MailApp.getRemainingDailyQuota() < 1) {
+      setNotificationState_(
+        sheet,
+        rowNumber,
+        false,
+        attempts,
+        "Mail quota exhausted",
+      );
+      return false;
+    }
+
+    const categoryLabel =
+      VOC_CATEGORY_LABELS[submission.category] || VOC_CATEGORY_LABELS.other;
+    const subjectTitle = submission.title.replace(/[\r\n]+/g, " ");
+    const body = [
+      "LinKU에 새로운 의견이 도착했습니다.",
+      "",
+      "유형: " + categoryLabel,
+      "제목: " + submission.title,
+      "내용:",
+      submission.message,
+      "",
+      "확장 프로그램 버전: " + submission.extensionVersion,
+      "제출 ID: " + submission.submissionId,
+      "Sheet: " + spreadsheetUrl,
+    ].join("\n");
+
+    MailApp.sendEmail({
+      to: recipientEmail,
+      subject: "[LinKU VoC/" + categoryLabel + "] " + subjectTitle,
+      body: body,
+      name: "LinKU VoC",
+    });
+    setNotificationState_(sheet, rowNumber, true, attempts, "");
+    return true;
+  } catch (error) {
+    try {
+      setNotificationState_(
+        sheet,
+        rowNumber,
+        false,
+        attempts,
+        getPrivateErrorMessage_(error),
+      );
+    } catch (_stateError) {
+      // Sheet 본문은 이미 저장됐으므로 알림 상태 기록 실패도 제출 실패로 바꾸지 않습니다.
+    }
+    return false;
+  }
+}
+
+function setNotificationState_(sheet, rowNumber, sent, attempts, error) {
+  sheet
+    .getRange(rowNumber, 8, 1, 3)
+    .setValues([[sent, attempts, safeSheetText_(error).slice(0, 200)]]);
+}
+
+function installRetryTrigger_() {
+  const alreadyInstalled = ScriptApp.getProjectTriggers().some(
+    (trigger) =>
+      trigger.getHandlerFunction() === VOC_CONFIG.retryFunctionName &&
+      trigger.getEventType() === ScriptApp.EventType.CLOCK,
+  );
+  if (alreadyInstalled) return;
+
+  ScriptApp.newTrigger(VOC_CONFIG.retryFunctionName)
+    .timeBased()
+    .everyHours(6)
+    .create();
+}
+
+function enforceRateLimit_(clientId) {
+  const cache = CacheService.getScriptCache();
+  const digest = Utilities.computeDigest(
+    Utilities.DigestAlgorithm.SHA_256,
+    clientId,
+  )
+    .slice(0, 12)
+    .map((value) => (value + 256).toString(16).slice(-2))
+    .join("");
+  const key = "voc-rate-" + digest;
+  const requestCount = Number(cache.get(key) || 0);
+
+  if (requestCount >= VOC_CONFIG.maxRequestsPerMinute) {
+    throw new Error("RATE_LIMITED");
+  }
+  cache.put(key, String(requestCount + 1), 60);
+}
+
+function normalizeText_(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function safeSheetText_(value) {
+  const text = String(value == null ? "" : value);
+  return /^[=+\-@]/.test(text) ? "'" + text : text;
+}
+
+function getPrivateErrorMessage_(error) {
+  return error && error.message ? String(error.message) : String(error);
+}
+
+function getErrorCode_(error) {
+  const message = getPrivateErrorMessage_(error);
+  const publicCodes = [
+    "INVALID_PAYLOAD",
+    "RATE_LIMITED",
+    "NOT_CONFIGURED",
+    "INVALID_SHEET_SCHEMA",
+  ];
+  return publicCodes.includes(message) ? message : "INTERNAL_ERROR";
+}
+
+function jsonResponse_(payload) {
+  return ContentService.createTextOutput(JSON.stringify(payload)).setMimeType(
+    ContentService.MimeType.JSON,
+  );
+}

--- a/integrations/apps-script-voc/Code.gs
+++ b/integrations/apps-script-voc/Code.gs
@@ -5,12 +5,15 @@ const VOC_CONFIG = Object.freeze({
   defaultSheetName: "Feedback",
   spreadsheetName: "LinKU VoC",
   digestFunctionName: "sendDailyDigest",
-  legacyRetryFunctionName: "retryPendingNotifications",
   lastDigestDateProperty: "VOC_LAST_DIGEST_DATE",
+  intakeDateProperty: "VOC_INTAKE_DATE",
+  intakeCountProperty: "VOC_INTAKE_COUNT",
   digestHour: 9,
   digestTimezone: "Asia/Seoul",
   maxDigestBodyBytes: 180 * 1024,
-  maxRequestsPerMinute: 10,
+  maxRequestsPerMinute: 30,
+  maxSubmissionsPerDay: 500,
+  rateLimitCacheKey: "voc-global-rate-limit",
 });
 
 const VOC_HEADERS = Object.freeze([
@@ -98,7 +101,6 @@ function doPost(event) {
 
   try {
     const submission = parseSubmission_(event);
-    enforceRateLimit_(submission.clientId);
 
     lock = LockService.getScriptLock();
     if (!lock.tryLock(10000)) {
@@ -114,19 +116,24 @@ function doPost(event) {
     const sheet = getOrCreateFeedbackSheet_(spreadsheet);
     const existingRow = findSubmissionRow_(sheet, submission.submissionId);
     const duplicate = existingRow !== null;
-    const rowNumber = duplicate
-      ? existingRow
-      : appendSubmission_(sheet, submission);
+    if (duplicate) {
+      return jsonResponse_({
+        success: true,
+        persisted: true,
+        duplicate: true,
+      });
+    }
+
+    enforceIntakeBudget_();
+    appendSubmission_(sheet, submission);
 
     // Sheet 반영만 즉시 확정하고, 메일은 일일 다이제스트가 별도로 처리합니다.
     SpreadsheetApp.flush();
-    const notificationSent = readSubmission_(sheet, rowNumber).notificationSent;
 
     return jsonResponse_({
       success: true,
       persisted: true,
-      duplicate: duplicate,
-      notificationSent: notificationSent,
+      duplicate: false,
     });
   } catch (error) {
     const errorCode = getErrorCode_(error);
@@ -234,13 +241,6 @@ function sendDailyDigest() {
   }
 }
 
-/**
- * 기존 6시간 트리거가 남아 있어도 하루 한 번만 발송되도록 하는 migration alias.
- */
-function retryPendingNotifications() {
-  return sendDailyDigest();
-}
-
 function parseSubmission_(event) {
   const contents =
     event && event.postData && typeof event.postData.contents === "string"
@@ -259,7 +259,6 @@ function parseSubmission_(event) {
   }
 
   const submissionId = normalizeText_(payload.submissionId);
-  const clientId = normalizeText_(payload.clientId);
   const category = normalizeText_(payload.category);
   const title = normalizeText_(payload.title).trim();
   const message = normalizeText_(payload.message).trim();
@@ -269,8 +268,6 @@ function parseSubmission_(event) {
 
   const valid =
     /^[A-Za-z0-9-]{20,64}$/.test(submissionId) &&
-    clientId.length >= 8 &&
-    clientId.length <= 128 &&
     Object.prototype.hasOwnProperty.call(VOC_CATEGORY_LABELS, category) &&
     title.length >= 2 &&
     title.length <= 80 &&
@@ -285,7 +282,6 @@ function parseSubmission_(event) {
 
   return {
     submissionId: submissionId,
-    clientId: clientId,
     category: category,
     title: title,
     message: message,
@@ -468,14 +464,10 @@ function setNotificationState_(sheet, rowNumber, sent, attempts, error) {
 }
 
 function installDailyDigestTrigger_() {
-  const managedHandlers = [
-    VOC_CONFIG.digestFunctionName,
-    VOC_CONFIG.legacyRetryFunctionName,
-  ];
   for (const trigger of ScriptApp.getProjectTriggers()) {
     if (
       trigger.getEventType() === ScriptApp.EventType.CLOCK &&
-      managedHandlers.includes(trigger.getHandlerFunction())
+      trigger.getHandlerFunction() === VOC_CONFIG.digestFunctionName
     ) {
       ScriptApp.deleteTrigger(trigger);
     }
@@ -490,22 +482,41 @@ function installDailyDigestTrigger_() {
     .create();
 }
 
-function enforceRateLimit_(clientId) {
+function enforceIntakeBudget_() {
   const cache = CacheService.getScriptCache();
-  const digest = Utilities.computeDigest(
-    Utilities.DigestAlgorithm.SHA_256,
-    clientId,
-  )
-    .slice(0, 12)
-    .map((value) => (value + 256).toString(16).slice(-2))
-    .join("");
-  const key = "voc-rate-" + digest;
-  const requestCount = Number(cache.get(key) || 0);
+  const requestCount = Number(
+    cache.get(VOC_CONFIG.rateLimitCacheKey) || 0,
+  );
 
   if (requestCount >= VOC_CONFIG.maxRequestsPerMinute) {
     throw new Error("RATE_LIMITED");
   }
-  cache.put(key, String(requestCount + 1), 60);
+  cache.put(
+    VOC_CONFIG.rateLimitCacheKey,
+    String(requestCount + 1),
+    60,
+  );
+
+  const properties = PropertiesService.getScriptProperties();
+  const intakeDate = Utilities.formatDate(
+    new Date(),
+    VOC_CONFIG.digestTimezone,
+    "yyyy-MM-dd",
+  );
+  const storedDate = properties.getProperty(VOC_CONFIG.intakeDateProperty);
+  const intakeCount =
+    storedDate === intakeDate
+      ? Number(properties.getProperty(VOC_CONFIG.intakeCountProperty) || 0)
+      : 0;
+
+  if (intakeCount >= VOC_CONFIG.maxSubmissionsPerDay) {
+    throw new Error("RATE_LIMITED");
+  }
+
+  properties.setProperties({
+    [VOC_CONFIG.intakeDateProperty]: intakeDate,
+    [VOC_CONFIG.intakeCountProperty]: String(intakeCount + 1),
+  });
 }
 
 function normalizeText_(value) {
@@ -526,10 +537,9 @@ function getErrorCode_(error) {
   const publicCodes = [
     "INVALID_PAYLOAD",
     "RATE_LIMITED",
-    "NOT_CONFIGURED",
-    "INVALID_SHEET_SCHEMA",
+    "BUSY",
   ];
-  return publicCodes.includes(message) ? message : "INTERNAL_ERROR";
+  return publicCodes.includes(message) ? message : "SERVICE_UNAVAILABLE";
 }
 
 function jsonResponse_(payload) {

--- a/integrations/apps-script-voc/appsscript.json
+++ b/integrations/apps-script-voc/appsscript.json
@@ -1,0 +1,6 @@
+{
+  "timeZone": "Asia/Seoul",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:content-scripts": "node scripts/checkContentScripts.js",
     "lint": "eslint .",
     "test:timetable": "node --experimental-strip-types --test tests/timetable/*.test.ts",
+    "test:feedback": "node --experimental-strip-types --test tests/feedback/*.test.ts",
     "test:todo": "node --experimental-strip-types --test tests/todo/*.test.ts",
     "preview": "vite preview",
     "deploy": "git subtree push --prefix gh-pages origin gh-pages"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-error-boundary": "^6.1.2",
     "react-router": "^8.3.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1

--- a/src/apis/feedback.ts
+++ b/src/apis/feedback.ts
@@ -1,0 +1,210 @@
+import type {
+  FeedbackCategory,
+  FeedbackDeliveryResult,
+  FeedbackEndpointResponse,
+  FeedbackSubmission,
+} from "@/types/feedback";
+import { getStorage, setStorage } from "@/utils/chrome";
+import { getOrCreateClientId } from "@/utils/clientId";
+import { errorLog } from "@/utils/logger";
+
+const FEEDBACK_OUTBOX_STORAGE_KEY = "linkuFeedbackOutboxV1";
+const MAX_OUTBOX_SIZE = 50;
+const REQUEST_TIMEOUT_MS = 12_000;
+
+interface FeedbackInput {
+  category: FeedbackCategory;
+  title: string;
+  message: string;
+}
+
+const activeDeliveries = new Map<
+  string,
+  Promise<FeedbackEndpointResponse>
+>();
+
+let outboxOperation = Promise.resolve();
+let activeFlush: Promise<void> | null = null;
+
+function getFeedbackEndpoint() {
+  return import.meta.env.VITE_VOC_ENDPOINT?.trim() ?? "";
+}
+
+function getExtensionVersion() {
+  try {
+    return chrome.runtime?.getManifest().version ?? "development";
+  } catch {
+    return "development";
+  }
+}
+
+function isFeedbackSubmission(value: unknown): value is FeedbackSubmission {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<FeedbackSubmission>;
+  return (
+    typeof candidate.submissionId === "string" &&
+    typeof candidate.clientId === "string" &&
+    typeof candidate.category === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.extensionVersion === "string" &&
+    typeof candidate.createdAt === "string" &&
+    typeof candidate.website === "string"
+  );
+}
+
+async function readOutbox() {
+  const stored = await getStorage<unknown>(FEEDBACK_OUTBOX_STORAGE_KEY);
+  if (!Array.isArray(stored)) return [];
+
+  return stored.filter(isFeedbackSubmission);
+}
+
+function withOutboxLock<T>(operation: () => Promise<T>): Promise<T> {
+  const result = outboxOperation.then(operation, operation);
+  outboxOperation = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function enqueueFeedback(submission: FeedbackSubmission) {
+  await withOutboxLock(async () => {
+    const outbox = await readOutbox();
+    if (outbox.some((item) => item.submissionId === submission.submissionId)) {
+      return;
+    }
+
+    if (outbox.length >= MAX_OUTBOX_SIZE) {
+      throw new Error("FEEDBACK_OUTBOX_FULL");
+    }
+
+    await setStorage({
+      [FEEDBACK_OUTBOX_STORAGE_KEY]: [...outbox, submission],
+    });
+  });
+}
+
+async function removeFromOutbox(submissionId: string) {
+  await withOutboxLock(async () => {
+    const outbox = await readOutbox();
+    const nextOutbox = outbox.filter(
+      (item) => item.submissionId !== submissionId,
+    );
+
+    if (nextOutbox.length !== outbox.length) {
+      await setStorage({ [FEEDBACK_OUTBOX_STORAGE_KEY]: nextOutbox });
+    }
+  });
+}
+
+async function postFeedback(submission: FeedbackSubmission) {
+  const activeDelivery = activeDeliveries.get(submission.submissionId);
+  if (activeDelivery) return activeDelivery;
+
+  const delivery = (async () => {
+    const endpoint = getFeedbackEndpoint();
+    if (!endpoint) throw new Error("FEEDBACK_ENDPOINT_NOT_CONFIGURED");
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(
+      () => controller.abort(),
+      REQUEST_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        body: JSON.stringify(submission),
+        redirect: "follow",
+        signal: controller.signal,
+      });
+
+      const responseBody = (await response.json()) as FeedbackEndpointResponse;
+      if (!response.ok || !responseBody.success || !responseBody.persisted) {
+        throw new Error(responseBody.error || "FEEDBACK_NOT_PERSISTED");
+      }
+
+      return responseBody;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  })();
+
+  activeDeliveries.set(submission.submissionId, delivery);
+  try {
+    return await delivery;
+  } finally {
+    activeDeliveries.delete(submission.submissionId);
+  }
+}
+
+async function deliverFeedback(submission: FeedbackSubmission) {
+  const response = await postFeedback(submission);
+
+  try {
+    await removeFromOutbox(submission.submissionId);
+  } catch (error) {
+    // Sheet 저장은 완료됐으므로 로컬 삭제 실패는 다음 중복 전송에서 정리합니다.
+    errorLog("[VoC] Failed to remove persisted feedback from outbox:", error);
+  }
+
+  return response;
+}
+
+export async function submitFeedback(
+  input: FeedbackInput,
+): Promise<FeedbackDeliveryResult> {
+  const submission: FeedbackSubmission = {
+    submissionId: crypto.randomUUID(),
+    clientId: await getOrCreateClientId(),
+    category: input.category,
+    title: input.title.trim(),
+    message: input.message.trim(),
+    extensionVersion: getExtensionVersion(),
+    createdAt: new Date().toISOString(),
+    website: "",
+  };
+
+  // 네트워크 요청보다 먼저 보관해 실패 시에도 다시 보낼 수 있게 합니다.
+  await enqueueFeedback(submission);
+
+  try {
+    const response = await deliverFeedback(submission);
+    return {
+      status: "persisted",
+      notificationSent: response.notificationSent === true,
+    };
+  } catch (error) {
+    errorLog("[VoC] Feedback queued for retry:", error);
+    return { status: "queued", notificationSent: false };
+  }
+}
+
+export function flushFeedbackOutbox() {
+  if (activeFlush) return activeFlush;
+
+  activeFlush = (async () => {
+    try {
+      const outbox = await readOutbox();
+
+      // 한 건의 실패가 뒤의 제출을 막지 않도록 각 항목을 독립적으로 처리합니다.
+      for (const submission of outbox) {
+        try {
+          await deliverFeedback(submission);
+        } catch (error) {
+          errorLog("[VoC] Outbox retry failed:", error);
+        }
+      }
+    } catch (error) {
+      errorLog("[VoC] Failed to read feedback outbox:", error);
+    }
+  })().finally(() => {
+    activeFlush = null;
+  });
+
+  return activeFlush;
+}

--- a/src/apis/feedback.ts
+++ b/src/apis/feedback.ts
@@ -5,7 +5,6 @@ import type {
   FeedbackSubmission,
 } from "@/types/feedback";
 import { getStorage, setStorage } from "@/utils/chrome";
-import { getOrCreateClientId } from "@/utils/clientId";
 import { errorLog } from "@/utils/logger";
 
 const FEEDBACK_OUTBOX_STORAGE_KEY = "linkuFeedbackOutboxV1";
@@ -27,7 +26,18 @@ let outboxOperation = Promise.resolve();
 let activeFlush: Promise<void> | null = null;
 
 function getFeedbackEndpoint() {
-  return import.meta.env.VITE_VOC_ENDPOINT?.trim() ?? "";
+  const endpoint = import.meta.env.VITE_VOC_ENDPOINT?.trim() ?? "";
+
+  try {
+    const url = new URL(endpoint);
+    return url.protocol === "https:" &&
+      url.hostname === "script.google.com" &&
+      /^\/macros\/s\/[^/]+\/exec$/.test(url.pathname)
+      ? url.toString()
+      : "";
+  } catch {
+    return "";
+  }
 }
 
 function getExtensionVersion() {
@@ -44,7 +54,6 @@ function isFeedbackSubmission(value: unknown): value is FeedbackSubmission {
   const candidate = value as Partial<FeedbackSubmission>;
   return (
     typeof candidate.submissionId === "string" &&
-    typeof candidate.clientId === "string" &&
     typeof candidate.category === "string" &&
     typeof candidate.title === "string" &&
     typeof candidate.message === "string" &&
@@ -160,7 +169,6 @@ export async function submitFeedback(
 ): Promise<FeedbackDeliveryResult> {
   const submission: FeedbackSubmission = {
     submissionId: crypto.randomUUID(),
-    clientId: await getOrCreateClientId(),
     category: input.category,
     title: input.title.trim(),
     message: input.message.trim(),
@@ -173,14 +181,13 @@ export async function submitFeedback(
   await enqueueFeedback(submission);
 
   try {
-    const response = await deliverFeedback(submission);
+    await deliverFeedback(submission);
     return {
       status: "persisted",
-      notificationSent: response.notificationSent === true,
     };
   } catch (error) {
     errorLog("[VoC] Feedback queued for retry:", error);
-    return { status: "queued", notificationSent: false };
+    return { status: "queued" };
   }
 }
 

--- a/src/apis/feedback.ts
+++ b/src/apis/feedback.ts
@@ -1,8 +1,11 @@
-import type {
-  FeedbackCategory,
-  FeedbackDeliveryResult,
-  FeedbackEndpointResponse,
-  FeedbackSubmission,
+import {
+  feedbackEndpointResponseSchema,
+  feedbackInputSchema,
+  feedbackSubmissionSchema,
+  type FeedbackDeliveryResult,
+  type FeedbackEndpointResponse,
+  type FeedbackInput,
+  type FeedbackSubmission,
 } from "@/types/feedback";
 import { getStorage, setStorage } from "@/utils/chrome";
 import { errorLog } from "@/utils/logger";
@@ -10,12 +13,6 @@ import { errorLog } from "@/utils/logger";
 const FEEDBACK_OUTBOX_STORAGE_KEY = "linkuFeedbackOutboxV1";
 const MAX_OUTBOX_SIZE = 50;
 const REQUEST_TIMEOUT_MS = 12_000;
-
-interface FeedbackInput {
-  category: FeedbackCategory;
-  title: string;
-  message: string;
-}
 
 const activeDeliveries = new Map<
   string,
@@ -48,26 +45,14 @@ function getExtensionVersion() {
   }
 }
 
-function isFeedbackSubmission(value: unknown): value is FeedbackSubmission {
-  if (!value || typeof value !== "object") return false;
-
-  const candidate = value as Partial<FeedbackSubmission>;
-  return (
-    typeof candidate.submissionId === "string" &&
-    typeof candidate.category === "string" &&
-    typeof candidate.title === "string" &&
-    typeof candidate.message === "string" &&
-    typeof candidate.extensionVersion === "string" &&
-    typeof candidate.createdAt === "string" &&
-    typeof candidate.website === "string"
-  );
-}
-
 async function readOutbox() {
   const stored = await getStorage<unknown>(FEEDBACK_OUTBOX_STORAGE_KEY);
   if (!Array.isArray(stored)) return [];
 
-  return stored.filter(isFeedbackSubmission);
+  return stored.flatMap((item) => {
+    const result = feedbackSubmissionSchema.safeParse(item);
+    return result.success ? [result.data] : [];
+  });
 }
 
 function withOutboxLock<T>(operation: () => Promise<T>): Promise<T> {
@@ -132,9 +117,17 @@ async function postFeedback(submission: FeedbackSubmission) {
         signal: controller.signal,
       });
 
-      const responseBody = (await response.json()) as FeedbackEndpointResponse;
+      const responseBody = feedbackEndpointResponseSchema.parse(
+        await response.json(),
+      );
       if (!response.ok || !responseBody.success || !responseBody.persisted) {
         throw new Error(responseBody.error || "FEEDBACK_NOT_PERSISTED");
+      }
+      if (
+        submission.contactEmail &&
+        responseBody.contactEmailStored !== true
+      ) {
+        throw new Error("FEEDBACK_CONTACT_EMAIL_NOT_PERSISTED");
       }
 
       return responseBody;
@@ -167,11 +160,15 @@ async function deliverFeedback(submission: FeedbackSubmission) {
 export async function submitFeedback(
   input: FeedbackInput,
 ): Promise<FeedbackDeliveryResult> {
+  const { contactEmail, title, message } = feedbackInputSchema.parse(input);
+
   const submission: FeedbackSubmission = {
     submissionId: crypto.randomUUID(),
-    category: input.category,
-    title: input.title.trim(),
-    message: input.message.trim(),
+    // 기존 Sheet 스키마와 아직 전송되지 않은 의견을 보존하기 위한 내부 기본값입니다.
+    category: "other",
+    title,
+    message,
+    contactEmail,
     extensionVersion: getExtensionVersion(),
     createdAt: new Date().toISOString(),
     website: "",

--- a/src/apis/feedback.ts
+++ b/src/apis/feedback.ts
@@ -1,16 +1,17 @@
 import {
   feedbackEndpointResponseSchema,
   feedbackInputSchema,
-  feedbackSubmissionSchema,
   type FeedbackDeliveryResult,
   type FeedbackEndpointResponse,
   type FeedbackInput,
   type FeedbackSubmission,
 } from "@/types/feedback";
-import { getStorage, setStorage } from "@/utils/chrome";
 import { errorLog } from "@/utils/logger";
+import {
+  readFeedbackOutbox,
+  writeFeedbackOutbox,
+} from "@/apis/feedbackOutbox";
 
-const FEEDBACK_OUTBOX_STORAGE_KEY = "linkuFeedbackOutboxV1";
 const MAX_OUTBOX_SIZE = 50;
 const REQUEST_TIMEOUT_MS = 12_000;
 
@@ -45,16 +46,6 @@ function getExtensionVersion() {
   }
 }
 
-async function readOutbox() {
-  const stored = await getStorage<unknown>(FEEDBACK_OUTBOX_STORAGE_KEY);
-  if (!Array.isArray(stored)) return [];
-
-  return stored.flatMap((item) => {
-    const result = feedbackSubmissionSchema.safeParse(item);
-    return result.success ? [result.data] : [];
-  });
-}
-
 function withOutboxLock<T>(operation: () => Promise<T>): Promise<T> {
   const result = outboxOperation.then(operation, operation);
   outboxOperation = result.then(
@@ -66,7 +57,7 @@ function withOutboxLock<T>(operation: () => Promise<T>): Promise<T> {
 
 async function enqueueFeedback(submission: FeedbackSubmission) {
   await withOutboxLock(async () => {
-    const outbox = await readOutbox();
+    const outbox = await readFeedbackOutbox();
     if (outbox.some((item) => item.submissionId === submission.submissionId)) {
       return;
     }
@@ -75,21 +66,19 @@ async function enqueueFeedback(submission: FeedbackSubmission) {
       throw new Error("FEEDBACK_OUTBOX_FULL");
     }
 
-    await setStorage({
-      [FEEDBACK_OUTBOX_STORAGE_KEY]: [...outbox, submission],
-    });
+    await writeFeedbackOutbox([...outbox, submission]);
   });
 }
 
 async function removeFromOutbox(submissionId: string) {
   await withOutboxLock(async () => {
-    const outbox = await readOutbox();
+    const outbox = await readFeedbackOutbox();
     const nextOutbox = outbox.filter(
       (item) => item.submissionId !== submissionId,
     );
 
     if (nextOutbox.length !== outbox.length) {
-      await setStorage({ [FEEDBACK_OUTBOX_STORAGE_KEY]: nextOutbox });
+      await writeFeedbackOutbox(nextOutbox);
     }
   });
 }
@@ -193,7 +182,7 @@ export function flushFeedbackOutbox() {
 
   activeFlush = (async () => {
     try {
-      const outbox = await readOutbox();
+      const outbox = await readFeedbackOutbox();
 
       // 한 건의 실패가 뒤의 제출을 막지 않도록 각 항목을 독립적으로 처리합니다.
       for (const submission of outbox) {

--- a/src/apis/feedbackOutbox.ts
+++ b/src/apis/feedbackOutbox.ts
@@ -1,0 +1,64 @@
+import {
+  feedbackSubmissionSchema,
+  type FeedbackSubmission,
+} from "../types/feedback.ts";
+
+const FEEDBACK_OUTBOX_STORAGE_KEY = "linkuFeedbackOutboxV1";
+
+function parseFeedbackOutbox(value: unknown): FeedbackSubmission[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((item) => {
+    const result = feedbackSubmissionSchema.safeParse(item);
+    return result.success ? [result.data] : [];
+  });
+}
+
+function getExtensionStorage(): chrome.storage.StorageArea | null {
+  return globalThis.chrome?.storage?.local ?? null;
+}
+
+function getWebStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readFeedbackOutbox(): Promise<FeedbackSubmission[]> {
+  const extensionStorage = getExtensionStorage();
+  if (extensionStorage) {
+    const stored = await extensionStorage.get(FEEDBACK_OUTBOX_STORAGE_KEY);
+    return parseFeedbackOutbox(stored[FEEDBACK_OUTBOX_STORAGE_KEY]);
+  }
+
+  const webStorage = getWebStorage();
+  if (!webStorage) return [];
+
+  const stored = webStorage.getItem(FEEDBACK_OUTBOX_STORAGE_KEY);
+  if (!stored) return [];
+
+  try {
+    return parseFeedbackOutbox(JSON.parse(stored));
+  } catch {
+    return [];
+  }
+}
+
+export async function writeFeedbackOutbox(
+  outbox: FeedbackSubmission[],
+): Promise<void> {
+  const extensionStorage = getExtensionStorage();
+  if (extensionStorage) {
+    await extensionStorage.set({ [FEEDBACK_OUTBOX_STORAGE_KEY]: outbox });
+    return;
+  }
+
+  const webStorage = getWebStorage();
+  if (!webStorage) {
+    throw new Error("FEEDBACK_OUTBOX_STORAGE_UNAVAILABLE");
+  }
+
+  webStorage.setItem(FEEDBACK_OUTBOX_STORAGE_KEY, JSON.stringify(outbox));
+}

--- a/src/components/Editor/ItemPropertiesPanel/ItemPropertiesPanel.tsx
+++ b/src/components/Editor/ItemPropertiesPanel/ItemPropertiesPanel.tsx
@@ -191,7 +191,7 @@ const ItemPropertiesPanelForm = ({
               }
             }}
             placeholder="예: 이캠퍼스"
-            className="h-8 text-sm"
+            className="h-8"
             maxLength={15}
           />
         </div>
@@ -205,7 +205,7 @@ const ItemPropertiesPanelForm = ({
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
-            className="h-8 text-sm"
+            className="h-8"
           />
         </div>
 

--- a/src/components/Editor/shared/InputGroup.tsx
+++ b/src/components/Editor/shared/InputGroup.tsx
@@ -67,7 +67,7 @@ export const InputGroup = ({ title, fields }: InputGroupProps) => {
               value={field.value}
               onChange={(e) => handleChange(field, e.target.value)}
               onBlur={() => handleBlur(field)}
-              className="h-8 text-sm"
+              className="h-8"
               placeholder={`${field.min}-${field.max}`}
             />
           </div>

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -1,0 +1,187 @@
+import { useState, type FormEvent } from "react";
+import { Mail } from "lucide-react";
+import { toast } from "sonner";
+
+import { submitFeedback } from "@/apis/feedback";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  feedbackCategories,
+  type FeedbackCategory,
+} from "@/types/feedback";
+import { sendButtonClick } from "@/utils/analytics";
+
+const MAX_TITLE_LENGTH = 80;
+const MAX_MESSAGE_LENGTH = 500;
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
+  const [category, setCategory] = useState<FeedbackCategory>("feature");
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canContinue = title.trim().length >= 2 && message.trim().length >= 10;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!canContinue || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      const result = await submitFeedback({ category, title, message });
+      sendButtonClick("voc_submit", "voc_dialog");
+
+      if (result.status === "persisted") {
+        toast.success("의견을 안전하게 저장했어요.", {
+          description: result.notificationSent
+            ? "담당자에게 메일 알림도 보냈습니다."
+            : "메일 알림은 나중에 자동으로 다시 시도합니다.",
+        });
+      } else {
+        toast.info("의견을 이 기기에 임시 저장했어요.", {
+          description: "다음에 LinKU를 열면 자동으로 다시 전송합니다.",
+        });
+      }
+
+      setCategory("feature");
+      setTitle("");
+      setMessage("");
+      onOpenChange(false);
+    } catch {
+      toast.error("의견을 저장하지 못했어요.", {
+        description: "잠시 후 다시 시도해 주세요.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[440px] gap-0 overflow-hidden border-main/20 p-0">
+        <DialogHeader className="bg-main/5 px-6 py-5 pr-12 text-left">
+          <div className="flex items-start gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-main/10 text-main">
+              <Mail className="size-5" aria-hidden="true" />
+            </div>
+            <div className="space-y-1.5">
+              <DialogTitle>LinKU에 의견 보내기</DialogTitle>
+              <DialogDescription>
+                불편했던 점이나 필요한 기능을 들려주세요.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <form className="space-y-5 px-6 py-5" onSubmit={handleSubmit}>
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium">의견 유형</legend>
+            <div className="grid grid-cols-2 gap-2">
+              {feedbackCategories.map((option) => {
+                const selected = option.value === category;
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selected}
+                    className={cn(
+                      "rounded-md border px-3 py-2 text-left text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-main/40",
+                      selected
+                        ? "border-main bg-main/5 font-medium text-main"
+                        : "border-border text-muted-foreground hover:border-main/40 hover:text-foreground",
+                    )}
+                    onClick={() => setCategory(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor="feedback-title">한 줄 요약</Label>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {title.length}/{MAX_TITLE_LENGTH}
+              </span>
+            </div>
+            <Input
+              id="feedback-title"
+              value={title}
+              maxLength={MAX_TITLE_LENGTH}
+              minLength={2}
+              placeholder="예: 공지 검색이 더 쉬웠으면 좋겠어요"
+              autoComplete="off"
+              required
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor="feedback-message">자세한 내용</Label>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {message.length}/{MAX_MESSAGE_LENGTH}
+              </span>
+            </div>
+            <Textarea
+              id="feedback-message"
+              value={message}
+              maxLength={MAX_MESSAGE_LENGTH}
+              minLength={10}
+              placeholder="어떤 상황에서 무엇이 불편했는지 알려주세요."
+              className="min-h-28"
+              required
+              onChange={(event) => setMessage(event.target.value)}
+            />
+          </div>
+
+          <p className="rounded-md bg-muted px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+            의견은 Google Sheet에 먼저 저장되고 메일은 알림 용도로만
+            발송됩니다. 전송이 어려우면 이 기기에 임시 보관한 뒤 다시
+            시도합니다. 개인정보나 학번은 적지 마세요.
+          </p>
+
+          <DialogFooter className="flex-row justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={isSubmitting}
+              onClick={() => onOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              disabled={!canContinue || isSubmitting}
+              className="bg-main text-white hover:bg-hover"
+            >
+              {isSubmitting ? "저장 중..." : "의견 보내기"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FeedbackDialog;

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -51,8 +51,8 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
       if (result.status === "persisted") {
         toast.success("의견을 안전하게 저장했어요.", {
           description: result.notificationSent
-            ? "담당자에게 메일 알림도 보냈습니다."
-            : "메일 알림은 나중에 자동으로 다시 시도합니다.",
+            ? "이 의견은 이미 VoC 다이제스트로 전달됐습니다."
+            : "담당자는 매일 오전 9시 다이제스트로 확인합니다.",
         });
       } else {
         toast.info("의견을 이 기기에 임시 저장했어요.", {
@@ -156,9 +156,9 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
           </div>
 
           <p className="rounded-md bg-muted px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-            의견은 Google Sheet에 먼저 저장되고 메일은 알림 용도로만
-            발송됩니다. 전송이 어려우면 이 기기에 임시 보관한 뒤 다시
-            시도합니다. 개인정보나 학번은 적지 마세요.
+            의견은 Google Sheet에 먼저 저장되고, 메일은 매일 오전 9시에 한
+            번만 모아서 발송됩니다. 전송이 어려우면 이 기기에 임시 보관한 뒤
+            다시 시도합니다. 개인정보나 학번은 적지 마세요.
           </p>
 
           <DialogFooter className="flex-row justify-end">

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -44,9 +44,7 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
       void sendButtonClick("voc_submit", "voc_dialog");
 
       if (result.status === "persisted") {
-        toast.success("의견을 접수했어요.", {
-          description: "담당자가 확인할게요.",
-        });
+        toast.success("소중한 의견 감사해요.");
       } else {
         toast.info("의견을 이 기기에 임시 저장했어요.", {
           description: "다음에 LinKU를 열면 자동으로 다시 전송합니다.",

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -49,10 +49,8 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
       sendButtonClick("voc_submit", "voc_dialog");
 
       if (result.status === "persisted") {
-        toast.success("의견을 안전하게 저장했어요.", {
-          description: result.notificationSent
-            ? "이 의견은 이미 VoC 다이제스트로 전달됐습니다."
-            : "담당자는 매일 오전 9시 다이제스트로 확인합니다.",
+        toast.success("의견을 접수했어요.", {
+          description: "담당자가 확인할게요.",
         });
       } else {
         toast.info("의견을 이 기기에 임시 저장했어요.", {
@@ -156,9 +154,8 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
           </div>
 
           <p className="rounded-md bg-muted px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-            의견은 Google Sheet에 먼저 저장되고, 메일은 매일 오전 9시에 한
-            번만 모아서 발송됩니다. 전송이 어려우면 이 기기에 임시 보관한 뒤
-            다시 시도합니다. 개인정보나 학번은 적지 마세요.
+            전송이 어려우면 이 기기에 임시 보관한 뒤 다시 시도합니다.
+            개인정보나 학번은 적지 마세요.
           </p>
 
           <DialogFooter className="flex-row justify-end">

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -3,27 +3,14 @@ import { Mail } from "lucide-react";
 import { toast } from "sonner";
 
 import { submitFeedback } from "@/apis/feedback";
+import UtilityDialog from "@/components/UtilityDialog";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
-import {
-  feedbackCategories,
-  type FeedbackCategory,
-} from "@/types/feedback";
+import { FEEDBACK_LIMITS, feedbackInputSchema } from "@/types/feedback";
 import { sendButtonClick } from "@/utils/analytics";
-
-const MAX_TITLE_LENGTH = 80;
-const MAX_MESSAGE_LENGTH = 500;
 
 interface FeedbackDialogProps {
   open: boolean;
@@ -31,22 +18,30 @@ interface FeedbackDialogProps {
 }
 
 const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
-  const [category, setCategory] = useState<FeedbackCategory>("feature");
+  const [contactEmail, setContactEmail] = useState("");
   const [title, setTitle] = useState("");
   const [message, setMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const canContinue = title.trim().length >= 2 && message.trim().length >= 10;
-
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!canContinue || isSubmitting) return;
+    if (isSubmitting) return;
+
+    const input = feedbackInputSchema.safeParse({
+      contactEmail,
+      title,
+      message,
+    });
+    if (!input.success) {
+      toast.error(input.error.issues[0]?.message ?? "입력 내용을 확인해 주세요.");
+      return;
+    }
 
     setIsSubmitting(true);
     try {
-      const result = await submitFeedback({ category, title, message });
-      sendButtonClick("voc_submit", "voc_dialog");
+      const result = await submitFeedback(input.data);
+      void sendButtonClick("voc_submit", "voc_dialog");
 
       if (result.status === "persisted") {
         toast.success("의견을 접수했어요.", {
@@ -58,7 +53,7 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
         });
       }
 
-      setCategory("feature");
+      setContactEmail("");
       setTitle("");
       setMessage("");
       onOpenChange(false);
@@ -72,112 +67,102 @@ const FeedbackDialog = ({ open, onOpenChange }: FeedbackDialogProps) => {
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[440px] gap-0 overflow-hidden border-main/20 p-0">
-        <DialogHeader className="bg-main/5 px-6 py-5 pr-12 text-left">
-          <div className="flex items-start gap-3">
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-main/10 text-main">
-              <Mail className="size-5" aria-hidden="true" />
-            </div>
-            <div className="space-y-1.5">
-              <DialogTitle>LinKU에 의견 보내기</DialogTitle>
-              <DialogDescription>
-                불편했던 점이나 필요한 기능을 들려주세요.
-              </DialogDescription>
-            </div>
-          </div>
-        </DialogHeader>
+    <UtilityDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={Mail}
+      title="LinKU에 의견 보내기"
+    >
+      <form className="space-y-5" noValidate onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <Label
+            htmlFor="feedback-contact-email"
+            className="flex items-baseline gap-1 whitespace-nowrap"
+          >
+            이메일
+            <span className="text-xs font-normal text-muted-foreground">
+              (답장을 받고 싶으신 경우에만 입력해 주세요)
+            </span>
+          </Label>
+          <Input
+            id="feedback-contact-email"
+            name="contactEmail"
+            type="email"
+            value={contactEmail}
+            maxLength={FEEDBACK_LIMITS.contactEmail.max}
+            placeholder="example@email.com"
+            autoComplete="email"
+            onChange={(event) => setContactEmail(event.target.value)}
+          />
+        </div>
 
-        <form className="space-y-5 px-6 py-5" onSubmit={handleSubmit}>
-          <fieldset className="space-y-2">
-            <legend className="text-sm font-medium">의견 유형</legend>
-            <div className="grid grid-cols-2 gap-2">
-              {feedbackCategories.map((option) => {
-                const selected = option.value === category;
+        <div className="space-y-2">
+          <Label
+            htmlFor="feedback-title"
+            className="flex items-center gap-1"
+          >
+            제목
+            <span className="text-destructive" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only">(필수)</span>
+          </Label>
+          <Input
+            id="feedback-title"
+            name="title"
+            value={title}
+            maxLength={FEEDBACK_LIMITS.title.max}
+            minLength={FEEDBACK_LIMITS.title.min}
+            placeholder="한 줄로 적어주세요"
+            autoComplete="off"
+            required
+            onChange={(event) => setTitle(event.target.value)}
+          />
+        </div>
 
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    aria-pressed={selected}
-                    className={cn(
-                      "rounded-md border px-3 py-2 text-left text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-main/40",
-                      selected
-                        ? "border-main bg-main/5 font-medium text-main"
-                        : "border-border text-muted-foreground hover:border-main/40 hover:text-foreground",
-                    )}
-                    onClick={() => setCategory(option.value)}
-                  >
-                    {option.label}
-                  </button>
-                );
-              })}
-            </div>
-          </fieldset>
+        <div className="space-y-2">
+          <Label
+            htmlFor="feedback-message"
+            className="flex items-center gap-1"
+          >
+            내용
+            <span className="text-destructive" aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only">(필수)</span>
+          </Label>
+          <Textarea
+            id="feedback-message"
+            name="message"
+            value={message}
+            maxLength={FEEDBACK_LIMITS.message.max}
+            minLength={FEEDBACK_LIMITS.message.min}
+            placeholder="의견을 자유롭게 적어주세요"
+            className="min-h-28"
+            required
+            onChange={(event) => setMessage(event.target.value)}
+          />
+        </div>
 
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="feedback-title">한 줄 요약</Label>
-              <span className="text-xs tabular-nums text-muted-foreground">
-                {title.length}/{MAX_TITLE_LENGTH}
-              </span>
-            </div>
-            <Input
-              id="feedback-title"
-              value={title}
-              maxLength={MAX_TITLE_LENGTH}
-              minLength={2}
-              placeholder="예: 공지 검색이 더 쉬웠으면 좋겠어요"
-              autoComplete="off"
-              required
-              onChange={(event) => setTitle(event.target.value)}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="feedback-message">자세한 내용</Label>
-              <span className="text-xs tabular-nums text-muted-foreground">
-                {message.length}/{MAX_MESSAGE_LENGTH}
-              </span>
-            </div>
-            <Textarea
-              id="feedback-message"
-              value={message}
-              maxLength={MAX_MESSAGE_LENGTH}
-              minLength={10}
-              placeholder="어떤 상황에서 무엇이 불편했는지 알려주세요."
-              className="min-h-28"
-              required
-              onChange={(event) => setMessage(event.target.value)}
-            />
-          </div>
-
-          <p className="rounded-md bg-muted px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-            전송이 어려우면 이 기기에 임시 보관한 뒤 다시 시도합니다.
-            개인정보나 학번은 적지 마세요.
-          </p>
-
-          <DialogFooter className="flex-row justify-end">
-            <Button
-              type="button"
-              variant="ghost"
-              disabled={isSubmitting}
-              onClick={() => onOpenChange(false)}
-            >
-              취소
-            </Button>
-            <Button
-              type="submit"
-              disabled={!canContinue || isSubmitting}
-              className="bg-main text-white hover:bg-hover"
-            >
-              {isSubmitting ? "저장 중..." : "의견 보내기"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <DialogFooter className="flex-row justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={isSubmitting}
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            className="bg-main text-white hover:bg-hover"
+          >
+            {isSubmitting ? "저장 중..." : "의견 보내기"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </UtilityDialog>
   );
 };
 

--- a/src/components/Labs/QRGeneratorSection.tsx
+++ b/src/components/Labs/QRGeneratorSection.tsx
@@ -180,7 +180,7 @@ const QRGeneratorSection = () => {
   };
 
   return (
-    <div className="space-y-4 pt-4 mt-4 border-t">
+    <div className="space-y-4">
       <h2 className="text-base font-semibold">QR 코드 생성</h2>
 
       <div className="space-y-3">

--- a/src/components/Labs/ServerClockSection.tsx
+++ b/src/components/Labs/ServerClockSection.tsx
@@ -58,7 +58,7 @@ const ServerClockSection = () => {
   };
 
   return (
-    <div className="space-y-4 pt-4 mt-4 border-t">
+    <div className="space-y-4">
       <h2 className="text-base font-semibold">서버시계</h2>
 
       <div className="space-y-3">

--- a/src/components/LabsDialog.tsx
+++ b/src/components/LabsDialog.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from "react";
+import { FlaskConical } from "lucide-react";
+import UtilityDialog from "@/components/UtilityDialog";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { usePersistentDialogTab } from "@/hooks/usePersistentDialogTab";
 import ServerClockSection from "./Labs/ServerClockSection";
 import QRGeneratorSection from "./Labs/QRGeneratorSection";
 import LibrarySeatSection from "./Labs/LibrarySeatSection";
@@ -17,30 +18,54 @@ interface LabsDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+const LABS_TABS = ["library", "clock", "qr"] as const;
+const LAST_LABS_TAB_STORAGE_KEY = "ui:lastLabsTab:v1";
+
 const LabsDialog = ({ open, onOpenChange }: LabsDialogProps) => {
+  const tabs = usePersistentDialogTab({
+    open,
+    storageKey: LAST_LABS_TAB_STORAGE_KEY,
+    values: LABS_TABS,
+    defaultValue: "library",
+    featureArea: "labs",
+  });
+
   useEffect(() => {
-    if (open) sendLabsOpen();
+    if (open) void sendLabsOpen();
   }, [open]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>실험실</DialogTitle>
-          <DialogDescription className="hidden">
-            실험적 기능들
-          </DialogDescription>
-        </DialogHeader>
+    <UtilityDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={FlaskConical}
+      title="실험실"
+      description="새 기능을 먼저 써보세요."
+    >
+      <Tabs
+        value={tabs.value}
+        onValueChange={tabs.onValueChange}
+        className="w-full"
+      >
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="library">도서관 좌석</TabsTrigger>
+          <TabsTrigger value="clock">서버 시계</TabsTrigger>
+          <TabsTrigger value="qr">QR 생성</TabsTrigger>
+        </TabsList>
 
-        <ScrollArea className="max-h-[60vh]">
-          <div className="space-y-6 pr-4">
-            <LibrarySeatSection />
-            <ServerClockSection />
-            <QRGeneratorSection />
-          </div>
-        </ScrollArea>
-      </DialogContent>
-    </Dialog>
+        <TabsContent value="library" className="mt-4">
+          <LibrarySeatSection />
+        </TabsContent>
+
+        <TabsContent value="clock" className="mt-4">
+          <ServerClockSection />
+        </TabsContent>
+
+        <TabsContent value="qr" className="mt-4">
+          <QRGeneratorSection />
+        </TabsContent>
+      </Tabs>
+    </UtilityDialog>
   );
 };
 

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react";
+import { memo, Suspense, useEffect, useState, type ReactNode } from "react";
 import { Outlet } from "react-router";
 import ImageCarousel from "./Tabs/ImageCarousel";
 import { GitHubSvg, LinkuLogoSvg } from "@/assets";
@@ -20,13 +20,41 @@ const MainLayout = () => {
   );
 };
 
-const Header = () => {
-  const [text, setText] = React.useState<string>("");
-  const [showSettings, setShowSettings] = useState(false);
-  const [showLabs, setShowLabs] = useState(false);
-  const [showFeedback, setShowFeedback] = useState(false);
+interface HeaderActionButtonProps {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}
 
-  React.useEffect(() => {
+type HeaderDialog = "feedback" | "labs" | "settings";
+
+const HeaderActionButton = ({
+  label,
+  onClick,
+  children,
+}: HeaderActionButtonProps) => {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main/40"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+const Header = () => {
+  const [text, setText] = useState("");
+  const [activeDialog, setActiveDialog] = useState<HeaderDialog | null>(null);
+
+  const handleDialogOpenChange = (open: boolean) => {
+    if (!open) setActiveDialog(null);
+  };
+
+  useEffect(() => {
     void flushFeedbackOutbox();
 
     const retryWhenOnline = () => void flushFeedbackOutbox();
@@ -61,48 +89,57 @@ const Header = () => {
           />
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
         </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <FlaskConical
-            className="w-5 h-5 text-gray-600 cursor-pointer"
-            onClick={() => setShowLabs(true)}
-          />
-          <Settings
-            className="w-5 h-5 text-gray-600 cursor-pointer"
-            onClick={() => {
-              sendButtonClick("settings_icon", "header");
-              setShowSettings(true);
-            }}
-          />
-          <GitHubSvg
-            className="w-5 h-5 text-gray-600 cursor-pointer"
+        <div className="grid w-32 shrink-0 grid-cols-4 items-center justify-items-center">
+          <HeaderActionButton
+            label="GitHub에서 보기"
             onClick={() => {
               sendButtonClick("github_icon", "header");
               window.open("https://github.com/Turtle-Hwan/LinKU");
             }}
-          />
-          <button
-            type="button"
-            aria-label="LinKU에 의견 보내기"
-            title="의견 보내기"
-            className="flex size-7 items-center justify-center rounded-md bg-main/10 text-main transition-colors hover:bg-main/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main/40"
+          >
+            <GitHubSvg className="size-4 fill-current" aria-hidden="true" />
+          </HeaderActionButton>
+          <HeaderActionButton
+            label="LinKU에 의견 보내기"
             onClick={() => {
               sendButtonClick("voc_icon", "header");
-              setShowFeedback(true);
+              setActiveDialog("feedback");
             }}
           >
-            <Mail className="size-4" aria-hidden="true" />
-          </button>
+            <Mail className="size-5" aria-hidden="true" />
+          </HeaderActionButton>
+          <HeaderActionButton
+            label="실험실 열기"
+            onClick={() => setActiveDialog("labs")}
+          >
+            <FlaskConical className="size-5" aria-hidden="true" />
+          </HeaderActionButton>
+          <HeaderActionButton
+            label="설정 열기"
+            onClick={() => {
+              sendButtonClick("settings_icon", "header");
+              setActiveDialog("settings");
+            }}
+          >
+            <Settings className="size-5" aria-hidden="true" />
+          </HeaderActionButton>
         </div>
       </div>
 
-      {/* 실험실 다이얼로그 */}
-      <LabsDialog open={showLabs} onOpenChange={setShowLabs} />
+      <LabsDialog
+        open={activeDialog === "labs"}
+        onOpenChange={handleDialogOpenChange}
+      />
 
-      {/* 설정 다이얼로그 */}
-      <SettingsDialog open={showSettings} onOpenChange={setShowSettings} />
+      <SettingsDialog
+        open={activeDialog === "settings"}
+        onOpenChange={handleDialogOpenChange}
+      />
 
-      {/* VoC 다이얼로그 */}
-      <FeedbackDialog open={showFeedback} onOpenChange={setShowFeedback} />
+      <FeedbackDialog
+        open={activeDialog === "feedback"}
+        onOpenChange={handleDialogOpenChange}
+      />
     </header>
   );
 };
@@ -127,6 +164,6 @@ const BannerImgSkeleton = () => {
   );
 };
 
-MainLayout.Header = React.memo(Header);
-MainLayout.Banner = React.memo(Banner);
-export default React.memo(MainLayout);
+MainLayout.Header = memo(Header);
+MainLayout.Banner = memo(Banner);
+export default memo(MainLayout);

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -3,9 +3,11 @@ import { Outlet } from "react-router";
 import ImageCarousel from "./Tabs/ImageCarousel";
 import { GitHubSvg, LinkuLogoSvg } from "@/assets";
 import { Input } from "./ui/input";
-import { Search, Settings, FlaskConical } from "lucide-react";
+import { Search, Settings, FlaskConical, Mail } from "lucide-react";
 import SettingsDialog from "./SettingsDialog";
 import LabsDialog from "./LabsDialog";
+import FeedbackDialog from "./FeedbackDialog";
+import { flushFeedbackOutbox } from "@/apis/feedback";
 import { sendButtonClick, sendSearchSubmit } from "@/utils/analytics";
 
 const MainLayout = () => {
@@ -22,6 +24,15 @@ const Header = () => {
   const [text, setText] = React.useState<string>("");
   const [showSettings, setShowSettings] = useState(false);
   const [showLabs, setShowLabs] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(false);
+
+  React.useEffect(() => {
+    void flushFeedbackOutbox();
+
+    const retryWhenOnline = () => void flushFeedbackOutbox();
+    window.addEventListener("online", retryWhenOnline);
+    return () => window.removeEventListener("online", retryWhenOnline);
+  }, []);
 
   return (
     <header className="px-4 py-3">
@@ -69,6 +80,18 @@ const Header = () => {
               window.open("https://github.com/Turtle-Hwan/LinKU");
             }}
           />
+          <button
+            type="button"
+            aria-label="LinKU에 의견 보내기"
+            title="의견 보내기"
+            className="flex size-7 items-center justify-center rounded-md bg-main/10 text-main transition-colors hover:bg-main/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main/40"
+            onClick={() => {
+              sendButtonClick("voc_icon", "header");
+              setShowFeedback(true);
+            }}
+          >
+            <Mail className="size-4" aria-hidden="true" />
+          </button>
         </div>
       </div>
 
@@ -77,6 +100,9 @@ const Header = () => {
 
       {/* 설정 다이얼로그 */}
       <SettingsDialog open={showSettings} onOpenChange={setShowSettings} />
+
+      {/* VoC 다이얼로그 */}
+      <FeedbackDialog open={showFeedback} onOpenChange={setShowFeedback} />
     </header>
   );
 };

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,16 +1,10 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
+import UtilityDialog from "@/components/UtilityDialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
-import { DialogDescription } from "@radix-ui/react-dialog";
+import { usePersistentDialogTab } from "@/hooks/usePersistentDialogTab";
 import {
   sendButtonClick,
   sendAuthLoginStart,
@@ -34,7 +28,15 @@ import {
   isGuestUser,
   UserProfile,
 } from "@/utils/oauth";
-import { Info, Palette, LogOut, Mail, User, Timer } from "lucide-react";
+import {
+  Info,
+  Palette,
+  LogOut,
+  Mail,
+  Settings as SettingsIcon,
+  Timer,
+  User,
+} from "lucide-react";
 import { toast } from "sonner";
 import { getChromeApi, getStorage, setStorage } from "@/utils/chrome";
 import { EmailVerificationDialog } from "@/components/EmailVerificationDialog";
@@ -56,6 +58,9 @@ interface SettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
+
+const SETTINGS_TABS = ["google", "ecampus"] as const;
+const LAST_SETTINGS_TAB_STORAGE_KEY = "ui:lastSettingsTab:v1";
 
 const ECampusCredential = () => {
   const [savedId, setSavedId] = useState<string>("");
@@ -690,38 +695,48 @@ const RealtimeTimer = () => {
 };
 
 const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
+  const tabs = usePersistentDialogTab({
+    open,
+    storageKey: LAST_SETTINGS_TAB_STORAGE_KEY,
+    values: SETTINGS_TABS,
+    defaultValue: "google",
+    featureArea: "settings",
+  });
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>설정</DialogTitle>
-          <DialogDescription className="hidden">설정</DialogDescription>
-        </DialogHeader>
+    <UtilityDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={SettingsIcon}
+      title="설정"
+      description="계정과 사용 환경을 관리해요."
+      contentClassName="sm:max-w-[480px]"
+    >
+      <Tabs
+        value={tabs.value}
+        onValueChange={tabs.onValueChange}
+        className="w-full"
+      >
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="google">Google / Konkuk 계정 연동</TabsTrigger>
+          <TabsTrigger value="ecampus">eCampus 계정</TabsTrigger>
+        </TabsList>
 
-        <Tabs defaultValue="google" className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="google">Google / Konkuk 계정 연동</TabsTrigger>
-            <TabsTrigger value="ecampus">eCampus 계정</TabsTrigger>
-          </TabsList>
+        <TabsContent value="google" className="space-y-4 mt-4">
+          <SettingsDialog.GoogleOAuth />
+          <div className="pt-4">
+            <SettingsDialog.TemplateEditor />
+          </div>
+        </TabsContent>
 
-          <TabsContent value="google" className="space-y-4 mt-4">
-            <SettingsDialog.GoogleOAuth />
-            <div className="pt-4">
-              <SettingsDialog.TemplateEditor />
-            </div>
-          </TabsContent>
-
-          <TabsContent value="ecampus" className="space-y-4 mt-4">
-            <SettingsDialog.ECampusCredential />
-            <div className="pt-4 border-t">
-              <SettingsDialog.RealtimeTimer />
-            </div>
-          </TabsContent>
-        </Tabs>
-
-        <DialogFooter className="flex flex-row gap-2 space-x-0" />
-      </DialogContent>
-    </Dialog>
+        <TabsContent value="ecampus" className="space-y-4 mt-4">
+          <SettingsDialog.ECampusCredential />
+          <div className="pt-4 border-t">
+            <SettingsDialog.RealtimeTimer />
+          </div>
+        </TabsContent>
+      </Tabs>
+    </UtilityDialog>
   );
 };
 

--- a/src/components/Tabs/Alerts/AlertSearch.tsx
+++ b/src/components/Tabs/Alerts/AlertSearch.tsx
@@ -25,7 +25,7 @@ const AlertSearch = ({ value, onValueChange }: AlertSearchProps) => {
         aria-label="공지사항 검색"
         placeholder="공지사항의 제목 혹은 내용 검색이 가능합니다"
         autoComplete="off"
-        className="pl-9 pr-9 text-sm [&::-webkit-search-cancel-button]:appearance-none"
+        className="pl-9 pr-9 [&::-webkit-search-cancel-button]:appearance-none"
       />
       {value.length > 0 && (
         <button

--- a/src/components/UtilityDialog.tsx
+++ b/src/components/UtilityDialog.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface UtilityDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  contentClassName?: string;
+}
+
+const UtilityDialog = ({
+  open,
+  onOpenChange,
+  icon: Icon,
+  title,
+  description,
+  children,
+  contentClassName,
+}: UtilityDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          "flex max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] max-w-[440px] flex-col gap-0 overflow-hidden border-main/20 p-0 sm:max-w-[440px]",
+          contentClassName,
+        )}
+      >
+        <DialogHeader className="shrink-0 gap-0 border-b border-main/10 bg-main/5 py-2 pr-12 pl-2 text-left">
+          <div className="flex items-center gap-3">
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-main/10 text-main">
+              <Icon className="size-[18px]" aria-hidden="true" />
+            </div>
+            <div className="flex min-w-0 items-baseline gap-2 whitespace-nowrap">
+              <DialogTitle className="shrink-0">{title}</DialogTitle>
+              {description ? (
+                <DialogDescription className="min-w-0 truncate leading-none">
+                  {description}
+                </DialogDescription>
+              ) : (
+                <DialogDescription className="sr-only">
+                  {title} 대화상자
+                </DialogDescription>
+              )}
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="min-h-0 overflow-y-auto px-5 py-4">{children}</div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default UtilityDialog;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -108,7 +108,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-base leading-none font-semibold", className)}
       {...props}
     />
   )

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-24 w-full resize-none rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm transition-colors outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/src/hooks/usePersistentDialogTab.ts
+++ b/src/hooks/usePersistentDialogTab.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  sendNavigationTabView,
+  type NavigationTabFeatureArea,
+  type NavigationTabViewSource,
+} from "@/utils/analytics";
+import { getStorage, setStorage } from "@/utils/chrome";
+import { errorLog } from "@/utils/logger";
+
+interface UsePersistentDialogTabOptions<T extends string> {
+  open: boolean;
+  storageKey: string;
+  values: readonly T[];
+  defaultValue: T;
+  featureArea: NavigationTabFeatureArea;
+}
+
+function includesValue<T extends string>(
+  values: readonly T[],
+  value: unknown,
+): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+/**
+ * 다이얼로그 탭의 복원·저장과 실제 노출 측정을 한곳에서 관리합니다.
+ * 저장 실패는 탭 사용을 막지 않으며 다음 실행에서 기본값으로 복구됩니다.
+ */
+export function usePersistentDialogTab<T extends string>({
+  open,
+  storageKey,
+  values,
+  defaultValue,
+  featureArea,
+}: UsePersistentDialogTabOptions<T>) {
+  const [value, setValue] = useState<T>(defaultValue);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const initialViewSourceRef = useRef<NavigationTabViewSource>("default");
+  const hasUserSelectedRef = useRef(false);
+  const hasTrackedOpenRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!globalThis.chrome?.storage?.local) {
+      setIsHydrated(true);
+      return;
+    }
+
+    void getStorage<unknown>(storageKey)
+      .then((storedValue) => {
+        if (
+          cancelled ||
+          hasUserSelectedRef.current ||
+          !includesValue(values, storedValue)
+        ) {
+          return;
+        }
+
+        initialViewSourceRef.current = "restored";
+        setValue(storedValue);
+      })
+      .catch((error) => {
+        errorLog(`[Tabs] Failed to restore ${storageKey}:`, error);
+      })
+      .finally(() => {
+        if (!cancelled) setIsHydrated(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [storageKey, values]);
+
+  useEffect(() => {
+    if (!open) {
+      hasTrackedOpenRef.current = false;
+      return;
+    }
+
+    if (!isHydrated || hasTrackedOpenRef.current) return;
+
+    hasTrackedOpenRef.current = true;
+    void sendNavigationTabView(
+      featureArea,
+      value,
+      initialViewSourceRef.current,
+    );
+  }, [featureArea, isHydrated, open, value]);
+
+  const onValueChange = useCallback(
+    (nextValue: string) => {
+      if (!includesValue(values, nextValue) || nextValue === value) return;
+
+      hasUserSelectedRef.current = true;
+      initialViewSourceRef.current = "restored";
+      setValue(nextValue);
+
+      if (globalThis.chrome?.storage?.local) {
+        void setStorage({ [storageKey]: nextValue }).catch((error) => {
+          errorLog(`[Tabs] Failed to persist ${storageKey}:`, error);
+        });
+      }
+
+      if (open) {
+        hasTrackedOpenRef.current = true;
+        void sendNavigationTabView(featureArea, nextValue, "user_select");
+      }
+    },
+    [featureArea, open, storageKey, value, values],
+  );
+
+  return { value, onValueChange };
+}

--- a/src/types/feedback.ts
+++ b/src/types/feedback.ts
@@ -1,29 +1,88 @@
-export const feedbackCategories = [
-  { value: "feature", label: "기능 제안" },
-  { value: "bug", label: "오류 제보" },
-  { value: "experience", label: "사용 경험" },
-  { value: "other", label: "기타 의견" },
-] as const;
+import * as z from "zod/mini";
 
-export type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
+export const FEEDBACK_LIMITS = {
+  contactEmail: { max: 254 },
+  title: { min: 1, max: 80 },
+  message: { min: 1, max: 500 },
+} as const;
 
-export interface FeedbackSubmission {
-  submissionId: string;
-  category: FeedbackCategory;
-  title: string;
-  message: string;
-  extensionVersion: string;
-  createdAt: string;
-  website: string;
-}
+const feedbackCategorySchema = z.enum([
+  "feature",
+  "bug",
+  "experience",
+  "other",
+]);
 
-export interface FeedbackEndpointResponse {
-  success: boolean;
-  persisted: boolean;
-  duplicate?: boolean;
-  retryable?: boolean;
-  error?: string;
-}
+const feedbackContactEmailSchema = z.pipe(
+  z.string().check(
+    z.trim(),
+    z.toLowerCase(),
+    z.maxLength(
+      FEEDBACK_LIMITS.contactEmail.max,
+      `이메일은 ${FEEDBACK_LIMITS.contactEmail.max}자 이하로 입력해 주세요.`,
+    ),
+  ),
+  z.union([z.literal(""), z.email("이메일 주소를 확인해 주세요.")]),
+);
+
+const feedbackTitleSchema = z.string().check(
+  z.trim(),
+  z.minLength(
+    FEEDBACK_LIMITS.title.min,
+    `제목을 ${FEEDBACK_LIMITS.title.min}자 이상 입력해 주세요.`,
+  ),
+  z.maxLength(
+    FEEDBACK_LIMITS.title.max,
+    `제목은 ${FEEDBACK_LIMITS.title.max}자 이하로 입력해 주세요.`,
+  ),
+);
+
+const feedbackMessageSchema = z.string().check(
+  z.trim(),
+  z.minLength(
+    FEEDBACK_LIMITS.message.min,
+    `내용을 ${FEEDBACK_LIMITS.message.min}자 이상 입력해 주세요.`,
+  ),
+  z.maxLength(
+    FEEDBACK_LIMITS.message.max,
+    `내용은 ${FEEDBACK_LIMITS.message.max}자 이하로 입력해 주세요.`,
+  ),
+);
+
+export const feedbackInputSchema = z.object({
+  contactEmail: z._default(z.optional(feedbackContactEmailSchema), ""),
+  title: feedbackTitleSchema,
+  message: feedbackMessageSchema,
+});
+
+export type FeedbackInput = z.infer<typeof feedbackInputSchema>;
+
+export const feedbackSubmissionSchema = z.object({
+  submissionId: z.uuid(),
+  category: feedbackCategorySchema,
+  title: feedbackTitleSchema,
+  message: feedbackMessageSchema,
+  contactEmail: z.optional(feedbackContactEmailSchema),
+  extensionVersion: z.string().check(z.minLength(1)),
+  createdAt: z.iso.datetime(),
+  website: z.string(),
+});
+
+export type FeedbackCategory = z.infer<typeof feedbackCategorySchema>;
+export type FeedbackSubmission = z.infer<typeof feedbackSubmissionSchema>;
+
+export const feedbackEndpointResponseSchema = z.object({
+  success: z.boolean(),
+  persisted: z.boolean(),
+  duplicate: z.optional(z.boolean()),
+  contactEmailStored: z.optional(z.boolean()),
+  retryable: z.optional(z.boolean()),
+  error: z.optional(z.string()),
+});
+
+export type FeedbackEndpointResponse = z.infer<
+  typeof feedbackEndpointResponseSchema
+>;
 
 export interface FeedbackDeliveryResult {
   status: "persisted" | "queued";

--- a/src/types/feedback.ts
+++ b/src/types/feedback.ts
@@ -1,0 +1,33 @@
+export const feedbackCategories = [
+  { value: "feature", label: "기능 제안" },
+  { value: "bug", label: "오류 제보" },
+  { value: "experience", label: "사용 경험" },
+  { value: "other", label: "기타 의견" },
+] as const;
+
+export type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
+
+export interface FeedbackSubmission {
+  submissionId: string;
+  clientId: string;
+  category: FeedbackCategory;
+  title: string;
+  message: string;
+  extensionVersion: string;
+  createdAt: string;
+  website: string;
+}
+
+export interface FeedbackEndpointResponse {
+  success: boolean;
+  persisted: boolean;
+  duplicate?: boolean;
+  notificationSent?: boolean;
+  retryable?: boolean;
+  error?: string;
+}
+
+export interface FeedbackDeliveryResult {
+  status: "persisted" | "queued";
+  notificationSent: boolean;
+}

--- a/src/types/feedback.ts
+++ b/src/types/feedback.ts
@@ -9,7 +9,6 @@ export type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
 
 export interface FeedbackSubmission {
   submissionId: string;
-  clientId: string;
   category: FeedbackCategory;
   title: string;
   message: string;
@@ -22,12 +21,10 @@ export interface FeedbackEndpointResponse {
   success: boolean;
   persisted: boolean;
   duplicate?: boolean;
-  notificationSent?: boolean;
   retryable?: boolean;
   error?: string;
 }
 
 export interface FeedbackDeliveryResult {
   status: "persisted" | "queued";
-  notificationSent: boolean;
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -12,7 +12,7 @@
  * - setting_change: sendSettingChange (settings_credentials_saved/deleted 내부에서 병렬 발송)
  * - error         : sendError
  *
- * ### 신규 이벤트 (택소노미 정립 후 — `MP_` prefix)
+ * ### 도메인 이벤트 (기존 `MP_` 이름은 연속성 유지)
  * - Lifecycle  : sendExtensionOpen
  * - Search     : sendSearchSubmit
  * - Auth       : sendAuthLoginStart, sendAuthLoginSuccess, sendAuthLoginFail,
@@ -29,11 +29,12 @@
  * - Alerts     : sendAlertsView, sendAlertsItemOpen, sendAlertsSubscriptionChange
  * - Todo       : sendTodoView, sendTodoItemCreate, sendTodoItemComplete, sendTodoItemDelete
  * - Labs       : sendLabsOpen, sendLabsFeatureUse
+ * - Navigation : sendNavigationTabView
  * - Generic    : sendButtonClick (별도 이벤트 없는 범용 클릭)
  *
  * ## 설계 원칙
  * - sendGAEvent는 외부에 export하지 않는다. 호출 지점은 도메인 헬퍼만 import할 것
- * - MP_ prefix: 택소노미 정립 이전(레거시) / 이후 이벤트를 구분한다
+ * - 기존 MP_ 이벤트명은 연속성을 위해 유지하고 새 이벤트는 lower_snake_case를 사용한다
  * - 이벤트 네이밍과 파라미터 패턴: docs/GA4-Data-Taxonomy.md 기준을 따른다
  *
  * ## 전송 흐름
@@ -327,6 +328,26 @@ export async function sendTabChange(
   await sendGAEvent("tab_change", {
     tab_name: tabName,
     ...(featureArea && { feature_area: featureArea }),
+  });
+}
+
+export type NavigationTabFeatureArea = "labs" | "settings";
+export type NavigationTabViewSource =
+  | "default"
+  | "restored"
+  | "user_select";
+
+/** 다이얼로그 탭이 실제로 표시될 때 전송하는 진입 이벤트 */
+export async function sendNavigationTabView(
+  featureArea: NavigationTabFeatureArea,
+  tabName: string,
+  viewSource: NavigationTabViewSource,
+): Promise<void> {
+  await sendGAEvent("navigation_tab_view", {
+    feature_area: featureArea,
+    tab_name: tabName,
+    ui_location: "dialog",
+    view_source: viewSource,
   });
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="vite/client" />
 /// <reference types="chrome" />
+
+interface ImportMetaEnv {
+  readonly VITE_VOC_ENDPOINT?: string;
+}

--- a/tests/feedback/feedbackOutbox.test.ts
+++ b/tests/feedback/feedbackOutbox.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  readFeedbackOutbox,
+  writeFeedbackOutbox,
+} from "../../src/apis/feedbackOutbox.ts";
+import type { FeedbackSubmission } from "../../src/types/feedback.ts";
+
+const STORAGE_KEY = "linkuFeedbackOutboxV1";
+
+const submission: FeedbackSubmission = {
+  submissionId: "2e2163b0-813f-4d7d-8d21-f3b43dc68af8",
+  category: "other",
+  title: "문의 제목",
+  message: "문의 내용",
+  contactEmail: "reply@example.com",
+  extensionVersion: "1.0.0",
+  createdAt: "2026-08-09T00:00:00.000Z",
+  website: "",
+};
+
+function createWebStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function replaceGlobal(name: "chrome" | "localStorage", value: unknown) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+  });
+
+  return () => {
+    if (previous) {
+      Object.defineProperty(globalThis, name, previous);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
+test("웹에서는 localStorage outbox를 다시 읽을 수 있게 저장한다", async () => {
+  const webStorage = createWebStorage();
+  const restoreChrome = replaceGlobal("chrome", undefined);
+  const restoreWebStorage = replaceGlobal("localStorage", webStorage);
+
+  try {
+    await writeFeedbackOutbox([submission]);
+    assert.deepEqual(await readFeedbackOutbox(), [submission]);
+  } finally {
+    restoreWebStorage();
+    restoreChrome();
+  }
+});
+
+test("확장 환경에서는 chrome.storage.local을 우선한다", async () => {
+  const extensionValues: Record<string, unknown> = {};
+  const extensionStorage = {
+    get: async (key: string) => ({ [key]: extensionValues[key] }),
+    set: async (values: Record<string, unknown>) => {
+      Object.assign(extensionValues, values);
+    },
+  };
+  const webStorage = createWebStorage();
+  const restoreChrome = replaceGlobal("chrome", {
+    storage: { local: extensionStorage },
+  });
+  const restoreWebStorage = replaceGlobal("localStorage", webStorage);
+
+  try {
+    await writeFeedbackOutbox([submission]);
+    assert.deepEqual(extensionValues[STORAGE_KEY], [submission]);
+    assert.equal(webStorage.getItem(STORAGE_KEY), null);
+    assert.deepEqual(await readFeedbackOutbox(), [submission]);
+  } finally {
+    restoreWebStorage();
+    restoreChrome();
+  }
+});
+
+test("영구 저장소가 없으면 저장 성공으로 처리하지 않는다", async () => {
+  const restoreChrome = replaceGlobal("chrome", undefined);
+  const restoreWebStorage = replaceGlobal("localStorage", undefined);
+
+  try {
+    await assert.rejects(
+      writeFeedbackOutbox([submission]),
+      /FEEDBACK_OUTBOX_STORAGE_UNAVAILABLE/,
+    );
+  } finally {
+    restoreWebStorage();
+    restoreChrome();
+  }
+});


### PR DESCRIPTION
## Summary

- add a consistent inquiry entry point and feedback dialog with optional reply email, required title/content validation, and concise success feedback
- deliver feedback through an allowlisted endpoint with timeout handling, duplicate-safe IDs, and a local retry outbox
- add a Sheet-first Apps Script collector with bounded anonymous intake and one daily digest notification
- configure the public endpoint through repository variables while keeping recipient and Sheet configuration outside tracked source
- align utility dialog headers, input typography, icon spacing, and persisted Labs/Settings tab selection

## Verification

- `pnpm exec tsc -b`
- `pnpm run lint`
- `pnpm run test:timetable` — 10 passed
- `pnpm run test:todo` — 4 passed
- `pnpm run build:local`
- `node --check --input-type=commonjs < integrations/apps-script-voc/Code.gs`
- verified an actual extension submission was persisted through the deployed collector
- verified optional reply email and 1-character title/message boundaries
- verified daily digest generation and delivery behavior

## Security and operations

- no new Chrome extension permissions
- the endpoint is treated as public configuration; private recipient and Sheet values remain in Apps Script properties
- feedback is persisted before notification attempts, so mail quota or delivery failure does not discard submissions
